### PR TITLE
fix `use` parsing precedence issue

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -43,12 +43,15 @@ module.exports = grammar({
 
         /// Top Level Items
 
-        _declaration: $ => choice(
-            $.decl_alias,
-            $.decl_def,
-            $.decl_export,
-            $.decl_extern,
-            $.decl_use,
+        _declaration: $ => seq(
+            choice(
+                $.decl_alias,
+                $.decl_def,
+                $.decl_export,
+                $.decl_extern,
+                $.decl_use,
+            ),
+            optional(PUNC().semicolon),
         ),
 
         decl_alias: $ => seq(
@@ -79,7 +82,7 @@ module.exports = grammar({
             field("signature", choice($.parameter_parens, $.parameter_bracks)),
         ),
 
-        decl_use: $ => prec.left(1, seq(
+        decl_use: $ => prec.right(1, seq(
             optional(MODIFIER().visibility),
             KEYWORD().use,
             field("module", choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -109,27 +109,44 @@
       ]
     },
     "_declaration": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "decl_alias"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "decl_alias"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "decl_def"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "decl_export"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "decl_extern"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "decl_use"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "decl_def"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "decl_export"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "decl_extern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "decl_use"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -301,7 +318,7 @@
       ]
     },
     "decl_use": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",


### PR DESCRIPTION
this pr fixes a precedence issue when parsing a `use` declaration.

before
```nu
use "file.nu" some-cmd
------^------ ----^---
     use      pipeline
```

now
```nu
use "file.nu" some-cmd
----------^-----------
         use
```

it also allows an optional semicolon at the end of `use`, `def`, `def-env`, `export` and `alias`