### PR TITLE
add query files from LhKipp/nvim-nu

### DIFF
--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -47,7 +47,15 @@ let local = (
 let file = "highlights.scm"
 
 mkdir $local
-http get ([$remote $file] | str join "/") | save ($local | path join $file)
+
+[
+  highlights.scm
+  locals.scm
+  folds.scm
+  injections.scm
+] | each {|query|
+  http get ([$remote $query] | str join "/") | save ($local | path join $query)
+}
 ```
 
 [tree-sitter]: https://tree-sitter.github.io/tree-sitter/

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,0 +1,7 @@
+[
+  (function_definition)
+  (block)
+  (record_or_block)
+  (array)
+  (table)
+] @fold

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,13 @@
+; Scopes
+(function_definition) @scope
+
+; Definitions
+(variable_declaration 
+  name: (identifier) @definition.var)
+
+(function_definition
+  func_name: (identifier) @definition.function)
+
+; References
+(value_path) @reference
+(word) @reference


### PR DESCRIPTION
i've added the queries from https://github.com/LhKipp/nvim-nu :+1: 

> **Note**
> we have a lot more queries here, so i did not get them :relieved: 

### Command used
```nu
[folds injections locals] | each {|file|
    http get $"https://raw.githubusercontent.com/LhKipp/nvim-nu/main/queries/nu/($file).scm"
    | save $"queries/($file).scm"
}
```