### PR TITLE
Treat shebangs as regular comments in the highlights query

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -289,4 +289,5 @@
     ">" @punctuation.bracket
 )
 
+(shebang) @comment
 (comment) @comment


### PR DESCRIPTION
👋 😊

Shebang lines (`#!/some/binary --etc`) are a distinct type according to the grammar, but currently aren't included in the highlights query.

This change treats them as regular comments for the purpose of highlighting.