### PR TITLE
FIX: save with force the `hightlights.scm` file in *neovim` installation

### DIFF
--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -47,7 +47,7 @@ let local = (
 let file = "highlights.scm"
 
 mkdir $local
-http get ([$remote $file] | str join "/") | save ($local | path join $file)
+http get ([$remote $file] | str join "/") | save --force ($local | path join $file)
 ```
 
 [tree-sitter]: https://tree-sitter.github.io/tree-sitter/


### PR DESCRIPTION
each time i update this repo in *neovim* i run the script at the end of the *neovim* installation file and each time i get the following error :laughing: 

```
Error:
  × Destination file already exists
    ╭─[entry #1:10:1]
 10 │ mkdir $local
 11 │ http get ([$remote $file] | str join "/") | save ($local | path join $file)
    ·                                                  ─────────────┬────────────
    ·                                                               ╰── Destination file '/home/amtoine/.local/share/nvim/lazy/nvim-treesitter/queries/nu/highlights.scm' already exists
    ╰────
  help: you can use -f, --force to force overwriting the destination
```

this PR fixes this issue with `save --force` :ok_hand: 