### PR TITLE
Fix parsing of cell path

### DIFF
--- a/corpus/expr/cell_path.nu
+++ b/corpus/expr/cell_path.nu
@@ -51,3 +51,37 @@ let x = $list.PATH.4
           (cell_path
             (path)
             (path)))))))
+
+====
+cellpath-004-underscore-in-path
+=====
+
+let x = $env.LAST_EXIT_CODE
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_variable
+          (cell_path
+            (path)))))))
+
+====
+cellpath-005-hyphen-in-path
+=====
+
+let x = $nu.home-path
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_variable
+          (cell_path
+            (path)))))))

--- a/grammar.js
+++ b/grammar.js
@@ -860,7 +860,7 @@ module.exports = grammar({
         $._str_back_ticks,
       );
 
-      const path = choice(prec.right(2, token(/[0-9a-zA-Z]+/)), quoted);
+      const path = choice(prec.right(2, token(/[0-9a-zA-Z_-]+/)), quoted);
 
       return seq(
         PUNC().dot,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6625,7 +6625,7 @@
                       "type": "TOKEN",
                       "content": {
                         "type": "PATTERN",
-                        "value": "[0-9a-zA-Z]+"
+                        "value": "[0-9a-zA-Z_-]+"
                       }
                     }
                   },
@@ -6665,7 +6665,7 @@
                           "type": "TOKEN",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[0-9a-zA-Z]+"
+                            "value": "[0-9a-zA-Z_-]+"
                           }
                         }
                       },


### PR DESCRIPTION
Fix parsing when paths contain hyphens or underscores (e.g. `$nu.home-path`, `$env.LAST_EXIT_CODE`).
This fixes highlighting issues when paths contain hyphens or underscores.
Fix #33 