### PR TITLE
Fix parsing of command

### DIFF
--- a/corpus/decl/alias.nu
+++ b/corpus/decl/alias.nu
@@ -45,3 +45,25 @@ export alias change-directory = cd;
       (pipe_element
         (command
           (cmd_identifier))))))
+
+=====
+alias-000-terminated-by-newline
+=====
+
+alias less = bat
+let foo = "foo"
+
+-----
+
+(nu_script
+  (decl_alias
+    (cmd_identifier)
+    (pipeline
+      (pipe_element
+        (command
+          (cmd_identifier)))))
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_string)))))

--- a/corpus/expr/subexpr.nu
+++ b/corpus/expr/subexpr.nu
@@ -1,0 +1,224 @@
+=====
+subexpr-001-command
+=====
+
+(echo hello)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_string))))))))
+
+=====
+subexpr-002-multiline-command
+=====
+
+(
+  echo
+  one
+  two
+  thre
+)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_string)
+              (val_string)
+              (val_string))))))))
+
+=====
+subexpr-003-pipeline
+=====
+
+(ls | where size > 10kb)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)))
+          (pipe_element
+            (where_command
+              (val_string)
+              (val_filesize
+                (val_number)))))))))
+
+=====
+subexpr-004-pipeline-multiline
+=====
+
+(
+  echo
+  one
+  two
+  thre | str replace t T
+)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_string)
+              (val_string)
+              (val_string)))
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_string)
+              (val_string)
+              (val_string))))))))
+
+
+=====
+subexpr-005-assignment
+=====
+
+let xs = (echo one two)
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (expr_parenthesized
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_string)
+                (val_string)))))))))
+=====
+subexpr-006-multiline-assignment
+=====
+
+let xs = (echo
+one two)
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (expr_parenthesized
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_string)
+                (val_string)))))))))
+
+=====
+subexpr-007-path
+=====
+
+(ls).name
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier))))
+        (cell_path
+          (path))))))
+
+=====
+subexpr-008-contains-statement
+=====
+
+(let a = "hello";
+echo $a)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (stmt_let
+          (identifier)
+          (pipeline
+            (pipe_element
+              (val_string))))
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_variable
+                (identifier)))))))))
+
+=====
+subexpr-009-closure
+=====
+
+([1, 2, 3] | each
+{|x|
+  let y = 2
+  $x * $y
+})
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (val_list
+              (val_number)
+              (val_number)
+              (val_number)))
+          (pipe_element
+            (command
+              (cmd_identifier)
+              (val_closure
+                (parameter_pipes
+                  (parameter
+                    (identifier)))
+                (stmt_let
+                  (identifier)
+                  (pipeline
+                    (pipe_element
+                      (val_number))))
+                (pipeline
+                  (pipe_element
+                    (expr_binary
+                      (val_variable
+                        (identifier))
+                      (val_variable
+                        (identifier)))))))))))))

--- a/corpus/pipe/commands.nu
+++ b/corpus/pipe/commands.nu
@@ -186,3 +186,24 @@ echo n
       (command
         (cmd_identifier)
         (val_string)))))
+
+=====
+cmd-009-terminated-by-newline
+=====
+
+echo hello
+let x = 42
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number)))))

--- a/corpus/pipe/pipe.nu
+++ b/corpus/pipe/pipe.nu
@@ -121,3 +121,36 @@ pipe-005-unquoted-1-character
         (cmd_identifier)
         (val_string)
         (val_string)))))
+
+=====
+pipe-006-terminated-by-newline
+=====
+
+ls | each {|x| echo $x}
+let x = 42
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_variable
+                  (identifier)))))))))
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number)))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -627,6 +627,634 @@
         ]
       }
     },
+    "_block_body_statement_parenthesized": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_declaration_parenthesized"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_statement_parenthesized"
+        }
+      ]
+    },
+    "_declaration_parenthesized": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "decl_alias_parenthesized"
+          },
+          "named": true,
+          "value": "decl_alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_def"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_export"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_extern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_module"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_use"
+        }
+      ]
+    },
+    "decl_alias_parenthesized": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "export"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipeline_parenthesized"
+            },
+            "named": true,
+            "value": "pipeline"
+          }
+        }
+      ]
+    },
+    "stmt_let_parenthesized": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "let"
+              },
+              {
+                "type": "STRING",
+                "value": "let-env"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized"
+          }
+        ]
+      }
+    },
+    "stmt_mut_parenthesized": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "mut"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized"
+          }
+        ]
+      }
+    },
+    "stmt_const_parenthesized": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "export"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "const"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized"
+          }
+        ]
+      }
+    },
+    "_assignment_pattern_parenthesized": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_variable_name"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "param_type"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipeline_parenthesized"
+            },
+            "named": true,
+            "value": "pipeline"
+          }
+        }
+      ]
+    },
+    "_statement_parenthesized": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_control"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_stmt_hide"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_stmt_overlay"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stmt_register"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stmt_source"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_let_parenthesized"
+          },
+          "named": true,
+          "value": "stmt_let"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_mut_parenthesized"
+          },
+          "named": true,
+          "value": "stmt_mut"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_const_parenthesized"
+          },
+          "named": true,
+          "value": "stmt_const"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "pipeline_parenthesized"
+          },
+          "named": true,
+          "value": "pipeline"
+        }
+      ]
+    },
+    "pipeline_parenthesized": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_element_parenthesized"
+              },
+              "named": true,
+              "value": "pipe_element"
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipe_element_parenthesized_last"
+            },
+            "named": true,
+            "value": "pipe_element"
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
+    },
+    "_block_body_statement_parenthesized_last": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_declaration_parenthesized_last"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_statement_parenthesized_last"
+        }
+      ]
+    },
+    "_declaration_parenthesized_last": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "decl_alias_parenthesized_last"
+          },
+          "named": true,
+          "value": "decl_alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_def"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_export"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_extern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_module"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_use"
+        }
+      ]
+    },
+    "decl_alias_parenthesized_last": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "export"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipeline_parenthesized_last"
+            },
+            "named": true,
+            "value": "pipeline"
+          }
+        }
+      ]
+    },
+    "stmt_let_parenthesized_last": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "let"
+              },
+              {
+                "type": "STRING",
+                "value": "let-env"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized_last"
+          }
+        ]
+      }
+    },
+    "stmt_mut_parenthesized_last": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "mut"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized_last"
+          }
+        ]
+      }
+    },
+    "stmt_const_parenthesized_last": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "export"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "const"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_assignment_pattern_parenthesized_last"
+          }
+        ]
+      }
+    },
+    "_assignment_pattern_parenthesized_last": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_variable_name"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "param_type"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipeline_parenthesized_last"
+            },
+            "named": true,
+            "value": "pipeline"
+          }
+        }
+      ]
+    },
+    "_statement_parenthesized_last": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_control"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_stmt_hide"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_stmt_overlay"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stmt_register"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stmt_source"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_let_parenthesized_last"
+          },
+          "named": true,
+          "value": "stmt_let"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_mut_parenthesized_last"
+          },
+          "named": true,
+          "value": "stmt_mut"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "stmt_const_parenthesized_last"
+          },
+          "named": true,
+          "value": "stmt_const"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "pipeline_parenthesized_last"
+          },
+          "named": true,
+          "value": "pipeline"
+        }
+      ]
+    },
+    "pipeline_parenthesized_last": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_element_parenthesized"
+              },
+              "named": true,
+              "value": "pipe_element"
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipe_element_parenthesized_last"
+            },
+            "named": true,
+            "value": "pipe_element"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ";"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "_block_body": {
       "type": "SEQ",
       "members": [
@@ -2673,6 +3301,77 @@
         }
       ]
     },
+    "pipe_element_parenthesized": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PREC_RIGHT",
+              "value": 69,
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_ctrl_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "where_command"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_command_parenthesized_body"
+              },
+              "named": true,
+              "value": "command"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\n"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "|"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\n"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "pipe_element_last": {
       "type": "CHOICE",
       "members": [
@@ -2695,6 +3394,36 @@
         {
           "type": "SYMBOL",
           "name": "command"
+        }
+      ]
+    },
+    "pipe_element_parenthesized_last": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_RIGHT",
+          "value": 69,
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ctrl_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "where_command"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_parenthesized_body"
+          },
+          "named": true,
+          "value": "command"
         }
       ]
     },
@@ -5296,7 +6025,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block_body"
+          "name": "_parenthesized_body"
         },
         {
           "type": "STRING",
@@ -5313,6 +6042,45 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "_parenthesized_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_body_statement_parenthesized"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_terminator"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_block_body_statement_parenthesized_last"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_terminator"
+          }
         }
       ]
     },
@@ -6769,6 +7537,23 @@
           "content": {
             "type": "REPEAT",
             "content": {
+              "type": "SYMBOL",
+              "name": "_cmd_arg"
+            }
+          }
+        }
+      ]
+    },
+    "_command_parenthesized_body": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "head",
+            "content": {
               "type": "SEQ",
               "members": [
                 {
@@ -6776,7 +7561,7 @@
                   "members": [
                     {
                       "type": "STRING",
-                      "value": "\n"
+                      "value": "^"
                     },
                     {
                       "type": "BLANK"
@@ -6785,13 +7570,53 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "_cmd_arg"
+                  "name": "cmd_identifier"
                 }
               ]
             }
+          },
+          {
+            "type": "PREC_DYNAMIC",
+            "value": 10,
+            "content": {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\n"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_cmd_arg"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\n"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
-        }
-      ]
+        ]
+      }
     },
     "_cmd_arg": {
       "type": "CHOICE",
@@ -7073,16 +7898,32 @@
       "_declaration_last"
     ],
     [
+      "_declaration_parenthesized",
+      "_declaration_parenthesized_last"
+    ],
+    [
       "_statement",
       "_statement_last"
+    ],
+    [
+      "_statement_parenthesized",
+      "_statement_parenthesized_last"
     ],
     [
       "pipeline",
       "pipeline_last"
     ],
     [
+      "pipeline_parenthesized",
+      "pipeline_parenthesized_last"
+    ],
+    [
       "pipe_element",
       "pipe_element_last"
+    ],
+    [
+      "pipe_element_parenthesized",
+      "pipe_element_parenthesized_last"
     ],
     [
       "command"


### PR DESCRIPTION
Fix #45 , Fix #47 

Under the current rule for parsing of command, whether the command is a subexpression or not, line breaks are allowed between command arguments.
This causes the parser to fail to correctly detect the end of a command or pipeline.
This pr changes the rules to allow line breaks between command arguments only when the command is a subexpression.

After this change, the highlights looks like follows
![スクリーンショット 2023-12-27 215258](https://github.com/nushell/tree-sitter-nu/assets/17674842/e1549800-857f-4653-aebc-09dfe8f2f883)
![スクリーンショット 2023-12-27 215503](https://github.com/nushell/tree-sitter-nu/assets/17674842/0389e7a9-94da-4b41-83b1-661ac6f46303)
