### PR TITLE
Change to parse composite types

### DIFF
--- a/corpus/decl/def.nu
+++ b/corpus/decl/def.nu
@@ -350,3 +350,280 @@ def test [
         (param_type
           (flat_type))))
     (block)))
+
+======
+def-019-type-list-of-list
+======
+
+def test [
+  x: list<list<int>>
+]: nothing -> list<list<int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (list_type
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (list_type
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-020-type-list-of-record
+======
+
+def test [
+  x: list<record<key: string>>
+]: nothing -> list<record<key: string>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (list_type
+            (collection_type
+              (identifier)
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (list_type
+        (collection_type
+          (identifier)
+          (flat_type))))
+    (block)))
+
+======
+def-021-type-list-of-table
+======
+
+def test [
+  x: list<table<key1: string, key2: int>>
+]: nothing -> list<table<key1: string, key2: int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (list_type
+            (collection_type
+              (identifier)
+              (flat_type)
+              (identifier)
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (list_type
+        (collection_type
+          (identifier)
+          (flat_type)
+          (identifier)
+          (flat_type))))
+    (block)))
+
+======
+def-022-type-record-of-list
+======
+
+def test [
+  x: record<key: list<int>>
+]: nothing -> record<key: list<int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-023-type-record-of-record
+======
+
+def test [
+  x: record<key: list<int>>
+]: nothing -> record<key: list<int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-024-type-record-of-table
+======
+
+def test [
+  x: record<key: table<key: int>>
+]: nothing -> record<key: table<key: int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (collection_type
+              (identifier)
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (collection_type
+          (identifier)
+          (flat_type))))
+    (block)))
+
+======
+def-025-type-table-of-list
+======
+
+def test [
+  x: table<key: list<string>>
+]: nothing -> table<key: list<string>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-026-type-table-of-record
+======
+
+def test [
+  x: table<key: record<key1: string, key2: int>>
+]: nothing -> table<key: record<key1: string, key2: int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (collection_type
+              (identifier)
+              (flat_type)
+              (identifier)
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (collection_type
+          (identifier)
+          (flat_type)
+          (identifier)
+          (flat_type))))
+    (block)))
+
+======
+def-027-type-table-of-table
+======
+
+def test [
+  x: table<key: table<key1: string, key2: int>>
+]: nothing -> table<key: table<key1: string, key2: int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (collection_type
+              (identifier)
+              (flat_type)
+              (identifier)
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (collection_type
+          (identifier)
+          (flat_type)
+          (identifier)
+          (flat_type))))
+    (block)))

--- a/corpus/decl/def.nu
+++ b/corpus/decl/def.nu
@@ -627,3 +627,86 @@ def test [
           (identifier)
           (flat_type))))
     (block)))
+
+======
+def-028-type-one-line
+======
+
+def test [x: record<key: list<int>>]: nothing -> record<key: list<int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-029-type-two-line
+======
+
+def test [x: record<key: list<int>>
+]: nothing -> record<key: list<int>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))
+
+======
+def-030-type-two-line
+======
+
+def test [x: record<key: list<int>>]: nothing -> record<key: list<int>> {
+}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (list_type
+              (flat_type))))))
+    (returns
+      (flat_type)
+      (collection_type
+        (identifier)
+        (list_type
+          (flat_type))))
+    (block)))

--- a/grammar.js
+++ b/grammar.js
@@ -178,6 +178,9 @@ module.exports = grammar({
     _type_annotation: ($) =>
       field("type", choice($.list_type, $.collection_type, $.flat_type)),
 
+    _all_type: ($) =>
+      field("type", choice($.list_type, $.collection_type, $.flat_type)),
+
     flat_type: ($) => field("flat_type", FLAT_TYPES()),
 
     collection_type: ($) => {
@@ -192,7 +195,7 @@ module.exports = grammar({
           token.immediate(BRACK().open_angle),
           repeat(
             seq(
-              seq(key, optional(seq(PUNC().colon, $.flat_type))),
+              seq(key, optional(seq(PUNC().colon, $._all_type))),
               optional(PUNC().comma),
             ),
           ),
@@ -206,7 +209,7 @@ module.exports = grammar({
         "list",
         seq(
           token.immediate(BRACK().open_angle),
-          field("inner", optional($.flat_type)),
+          field("inner", optional($._all_type)),
           BRACK().close_angle,
         ),
       ),
@@ -1407,7 +1410,6 @@ function SPECIAL() {
 
 /// nushell flat types
 /// taken from `nu_parser::parser::parse_shape_name()`
-// i.e not composite types like list<int> or record<name: string>
 function FLAT_TYPES() {
   // prettier-ignore
   const types = [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1986,6 +1986,27 @@
         ]
       }
     },
+    "_all_type": {
+      "type": "FIELD",
+      "name": "type",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "list_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "collection_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "flat_type"
+          }
+        ]
+      }
+    },
     "flat_type": {
       "type": "FIELD",
       "name": "flat_type",
@@ -2207,7 +2228,7 @@
                               },
                               {
                                 "type": "SYMBOL",
-                                "name": "flat_type"
+                                "name": "_all_type"
                               }
                             ]
                           },
@@ -2266,7 +2287,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "flat_type"
+                    "name": "_all_type"
                   },
                   {
                     "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -254,17 +254,25 @@
             "named": true
           }
         ]
+      },
+      "type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "collection_type",
+            "named": true
+          },
+          {
+            "type": "flat_type",
+            "named": true
+          },
+          {
+            "type": "list_type",
+            "named": true
+          }
+        ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "flat_type",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2426,7 +2434,33 @@
         "required": false,
         "types": [
           {
+            "type": "collection_type",
+            "named": true
+          },
+          {
             "type": "flat_type",
+            "named": true
+          },
+          {
+            "type": "list_type",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "collection_type",
+            "named": true
+          },
+          {
+            "type": "flat_type",
+            "named": true
+          },
+          {
+            "type": "list_type",
             "named": true
           }
         ]


### PR DESCRIPTION
This change makes it possible to parse composite types (e.g. `list<record<key: string>>`, `record<key: list<int>>`)