### PR TITLE
Add symbols to command identifier

### DIFF
--- a/corpus/decl/def.nu
+++ b/corpus/decl/def.nu
@@ -710,3 +710,17 @@ def test [x: record<key: list<int>>]: nothing -> record<key: list<int>> {
         (list_type
           (flat_type))))
     (block)))
+
+======
+def-031-name-special-keys
+======
+
+def a_-!? [] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks)
+    (block)))

--- a/grammar.js
+++ b/grammar.js
@@ -45,10 +45,10 @@ module.exports = grammar({
 
     /// Identifiers
     // NOTE:
-    // for simplicity, i used the `rust` definition of an identifier
+    // for simplicity, i used the `rust` definition of an identifier and some symbols
     // but in `nu` the rule is way more relaxed than this
 
-    cmd_identifier: ($) => token(/[_\p{XID_Start}][_\-\p{XID_Continue}]*/),
+    cmd_identifier: ($) => token(/[_\p{XID_Start}][_\-\p{XID_Continue}!?]*/),
 
     identifier: ($) => token(/[_\p{XID_Start}][_\p{XID_Continue}]*/),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1298,7 +1298,7 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[_\\p{XID_Start}][_\\-\\p{XID_Continue}]*"
+        "value": "[_\\p{XID_Start}][_\\-\\p{XID_Continue}!?]*"
       }
     },
     "identifier": {


### PR DESCRIPTION
Fix #63 

Although there are many available symbols, I added `?` that is actually used [here](https://github.com/nushell/nushell/blob/62272975f2244229099c903ab43322f3db7e8d00/toolkit.nu#L396) and `!` that is likely to be used.