### PR TITLE
Fix parsing of closure and record

### DIFF
--- a/corpus/expr/closure.nu
+++ b/corpus/expr/closure.nu
@@ -1,0 +1,103 @@
+=====
+closure-001-basic
+=====
+
+[1, 2] | each {|x| $x + 1 }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (val_number)
+        (val_number)))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable
+                  (identifier))
+                (val_number)))))))))
+
+=====
+closure-002-closure-without-parameter
+=====
+
+[1, 2, 3] | each {|| $in + 2 }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (val_number)
+        (val_number)
+        (val_number)))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes)
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable)
+                (val_number)))))))))
+
+=====
+closure-003-closure-without-parameter-pipes
+=====
+
+[1, 2] | each {
+  $in * 2
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (val_number)
+        (val_number)))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable)
+                (val_number)))))))))
+
+
+=====
+closure-004-cmd-args
+=====
+
+custom-cmd {|| 'hello' } { 'world' }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes)
+          (pipeline
+            (pipe_element
+              (val_string))))
+        (val_closure
+          (pipeline
+            (pipe_element
+              (val_string))))))))

--- a/corpus/expr/closure.nu
+++ b/corpus/expr/closure.nu
@@ -101,3 +101,83 @@ custom-cmd {|| 'hello' } { 'world' }
           (pipeline
             (pipe_element
               (val_string))))))))
+
+=====
+closure-005-let
+=====
+
+let cl = {
+  'closure'
+}
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_closure
+          (pipeline
+            (pipe_element
+              (val_string))))))))
+
+=====
+closure-006-let-parameter-pipes
+=====
+
+let cl = {|x|
+  $x * 3
+}
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_closure
+        (parameter_pipes
+          (parameter
+            (identifier)))
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable
+                  (identifier))
+                (val_number)))))))))
+
+=====
+closure-007-record-value
+=====
+
+{
+  closure: {|x| $x * 2}
+  closure2: { 'closure' }
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (identifier)
+          (val_closure
+            (parameter_pipes
+              (parameter
+                (identifier)))
+            (pipeline
+              (pipe_element
+                (expr_binary
+                  (val_variable
+                    (identifier))
+                  (val_number))))))
+        (record_entry
+          (identifier)
+          (val_closure
+            (pipeline
+              (pipe_element
+                (val_string)))))))))

--- a/corpus/expr/record.nu
+++ b/corpus/expr/record.nu
@@ -26,3 +26,108 @@ record-002-empty
   (pipeline
     (pipe_element
       (val_record))))
+
+=====
+record-003-number-key
+=====
+
+{
+  123: number
+  -457: number
+  +890: number
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (val_number)
+          (val_string))
+        (record_entry
+          (val_number)
+          (val_string))
+        (record_entry
+          (val_number)
+          (val_string))))))
+
+=====
+record-004-key-using-symbol
+=====
+
+{
+  -key: value,
+  +key: 'value'
+  --key-value: 'value'
+  key!: 'value'
+  key?: "value"
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (identifier)
+          (val_string))
+        (record_entry
+          (identifier)
+          (val_string))
+        (record_entry
+          (identifier)
+          (val_string))
+        (record_entry
+          (identifier)
+          (val_string))
+        (record_entry
+          (identifier)
+          (val_string))))))
+
+=====
+record-005-variable-key
+=====
+
+{$key: value}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (val_variable
+            (identifier))
+          (val_string))))))
+
+=====
+record-006-subexpression-key
+=====
+
+{
+  ([foo bar] | str join '-'): value
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (expr_parenthesized
+            (pipeline
+              (pipe_element
+                (val_list
+                  (val_string)
+                  (val_string)))
+              (pipe_element
+                (command
+                  (cmd_identifier)
+                  (val_string)
+                  (val_string)))))
+          (val_string))))))

--- a/corpus/expr/record.nu
+++ b/corpus/expr/record.nu
@@ -1,0 +1,28 @@
+=====
+record-001-basic
+=====
+
+{'key': 'value'}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_entry
+          (val_string)
+          (val_string))))))
+
+=====
+record-002-empty
+=====
+
+{}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record))))

--- a/grammar.js
+++ b/grammar.js
@@ -918,6 +918,13 @@ module.exports = grammar({
             // Without $.cmd_identifier, cannot correctly distinguish between record and closure
             alias($.cmd_identifier, $.identifier),
             $.val_string,
+            $.val_number,
+            $.val_variable,
+            $.expr_parenthesized,
+            alias($._record_key, $.identifier),
+
+            // This distinguish from number and identifier starting with -/+
+            alias(token(/[-+][^\s\n\t\r{}()\[\]"`';:,]*/), $.identifier),
           ),
         ),
         PUNC().colon,
@@ -930,6 +937,9 @@ module.exports = grammar({
         ),
         optional(PUNC().comma),
       ),
+
+    _record_key: ($) =>
+      token(prec(-69, /[^$\s\n\t\r{}()\[\]"`';:,][^\s\n\t\r{}()\[\]"`';:,]*/)),
 
     val_table: ($) =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4104,8 +4104,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "block"
+          "type": "PREC_DYNAMIC",
+          "value": 10,
+          "content": {
+            "type": "SYMBOL",
+            "name": "block"
+          }
         },
         {
           "type": "SYMBOL",
@@ -7659,8 +7663,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "cmd_identifier"
+                },
+                "named": true,
+                "value": "identifier"
               },
               {
                 "type": "SYMBOL",
@@ -7774,12 +7783,20 @@
           "value": "{"
         },
         {
-          "type": "FIELD",
-          "name": "parameters",
-          "content": {
-            "type": "SYMBOL",
-            "name": "parameter_pipes"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "parameters",
+              "content": {
+                "type": "SYMBOL",
+                "name": "parameter_pipes"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -8333,6 +8350,10 @@
     [
       "block",
       "val_record"
+    ],
+    [
+      "block",
+      "val_closure"
     ],
     [
       "ctrl_if_parenthesized"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7674,6 +7674,39 @@
               {
                 "type": "SYMBOL",
                 "name": "val_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "val_number"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "val_variable"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expr_parenthesized"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_record_key"
+                },
+                "named": true,
+                "value": "identifier"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[-+][^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                  }
+                },
+                "named": true,
+                "value": "identifier"
               }
             ]
           }
@@ -7721,6 +7754,17 @@
           ]
         }
       ]
+    },
+    "_record_key": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -69,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^$\\s\\n\\t\\r{}()\\[\\]\"`';:,][^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+        }
+      }
     },
     "val_table": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4076,7 +4076,7 @@
     "fields": {
       "parameters": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "parameter_pipes",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3548,11 +3548,23 @@
         "required": true,
         "types": [
           {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
             "type": "identifier",
             "named": true
           },
           {
+            "type": "val_number",
+            "named": true
+          },
+          {
             "type": "val_string",
+            "named": true
+          },
+          {
+            "type": "val_variable",
             "named": true
           }
         ]


### PR DESCRIPTION
Fix #67 
Fix #16 
Fix #65 

This change makes it possible to parse closure without parameter pipes.
And following types are parsed as record key
- unquoted string contains a hyphen
- number
- variable
- subexpression
