### PR TITLE
add query location to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
       "scope": "source.nu",
       "file-types": [
         "nu"
-      ]
+      ],
+      "highlights": "queries/nu/highlights.scm",
+      "injections": "queries/nu/injections.scm"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the tree-sitter query location to the package.json file so that `tree-sitter highlight ts.nu` works.