### PR TITLE
Fix parsing of match pattern

### DIFF
--- a/corpus/ctrl/match.nu
+++ b/corpus/ctrl/match.nu
@@ -65,3 +65,192 @@ match $x {
             (pipeline
               (pipe_element
                 (val_record)))))))))
+
+=====
+match-003-list
+=====
+
+match $xs {
+   [] => {},
+   [1] => {},
+   [1, 2] => {},
+   [$x] => {},
+   _ => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (val_list))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_number)
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_variable
+                (identifier))))
+          (block))
+        (default_arm
+          (block))))))
+
+=====
+match-004-range
+=====
+
+match $xs {
+   1..3 => {}
+   4..<6 => {}
+   6..=9 => {}
+   10.. => {}
+   [1..3, 4..<10] => {}
+   _ => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (val_range
+              (val_number)
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_range
+              (val_number)
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_range
+              (val_number)
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_range
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_range
+                (val_number)
+                (val_number))
+              (val_range
+                (val_number)
+                (val_number))))
+          (block))
+        (default_arm
+          (block))))))
+
+=====
+match-005-rest-pattern
+=====
+
+match $xs {
+   [1 ..$tail] => {}
+   [2, ..] => {}
+   [$head ..$tail] if ($tail | length) < 3 => {}
+   [..$tail] => {}
+   _ => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_number)
+              (val_variable
+                (identifier))))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_number)))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_variable
+                (identifier))
+              (val_variable
+                (identifier)))
+            (match_guard
+              (expr_binary
+                (expr_parenthesized
+                  (pipeline
+                    (pipe_element
+                      (val_variable
+                        (identifier)))
+                    (pipe_element
+                      (command
+                        (cmd_identifier)))))
+                (val_number))))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_variable
+                (identifier))))
+          (block))
+        (default_arm
+          (block))))))
+
+=====
+match-006-or
+=====
+
+match $xs {
+   [1] | [2 3] => {},
+   _ => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (val_list
+              (val_number))
+            (val_list
+              (val_number)
+              (val_number)))
+          (block))
+        (default_arm
+          (block))))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3190,24 +3190,11 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_match_or_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_match_list_destructure_pattern"
-        }
-      ]
-    },
-    "_match_or_pattern": {
-      "type": "SEQ",
-      "members": [
-        {
           "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression"
+              "name": "_match_pattern_expression"
             },
             {
               "type": "CHOICE",
@@ -3224,20 +3211,29 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "|"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_match_pattern_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_match_pattern_expression"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       ]
     },
@@ -3254,76 +3250,249 @@
         }
       ]
     },
-    "_match_list_destructure_pattern": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "["
+    "_match_pattern_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_match_pattern_value"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr_unary_minus"
           },
-          {
+          "named": true,
+          "value": "expr_unary"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_range"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expr_parenthesized"
+        }
+      ]
+    },
+    "_match_pattern_value": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "val_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_nothing"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_bool"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_duration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_filesize"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_binary"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_date"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_match_pattern_list"
+          },
+          "named": true,
+          "value": "val_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_record"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_table"
+        }
+      ]
+    },
+    "_match_pattern_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
             "type": "FIELD",
-            "name": "head",
+            "name": "item",
             "content": {
               "type": "SEQ",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": "$"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_match_pattern_expression"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_unquoted_in_list"
+                      },
+                      "named": true,
+                      "value": "val_string"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "short_flag"
+                      },
+                      "named": true,
+                      "value": "val_string"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "long_flag"
+                      },
+                      "named": true,
+                      "value": "val_string"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_list_item_starts_with_sign"
+                      },
+                      "named": true,
+                      "value": "val_string"
+                    }
+                  ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "FIELD",
-            "name": "tail",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "."
-                },
-                {
-                  "type": "STRING",
-                  "value": "."
-                },
-                {
-                  "type": "STRING",
-                  "value": "$"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "]"
           }
-        ]
-      }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "rest",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_match_pattern_rest"
+                    },
+                    "named": true,
+                    "value": "val_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_match_pattern_ignore_rest"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_match_pattern_rest": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "."
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "$"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        }
+      ]
+    },
+    "_match_pattern_ignore_rest": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "."
+          }
+        }
+      ]
     },
     "ctrl_try": {
       "type": "SEQ",
@@ -11058,6 +11227,18 @@
     [
       "_expression",
       "_expr_binary_expression"
+    ],
+    [
+      "_match_pattern_value",
+      "_value"
+    ],
+    [
+      "_match_pattern_expression",
+      "_list_item_expression"
+    ],
+    [
+      "_match_pattern_list",
+      "val_list"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2658,48 +2658,11 @@
   {
     "type": "match_pattern",
     "named": true,
-    "fields": {
-      "head": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "$",
-            "named": false
-          },
-          {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      },
-      "tail": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "$",
-            "named": false
-          },
-          {
-            "type": ".",
-            "named": false
-          },
-          {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
-        {
-          "type": "expr_binary",
-          "named": true
-        },
         {
           "type": "expr_parenthesized",
           "named": true
@@ -2721,10 +2684,6 @@
           "named": true
         },
         {
-          "type": "val_closure",
-          "named": true
-        },
-        {
           "type": "val_date",
           "named": true
         },
@@ -2734,10 +2693,6 @@
         },
         {
           "type": "val_filesize",
-          "named": true
-        },
-        {
-          "type": "val_interpolated",
           "named": true
         },
         {
@@ -4670,6 +4625,20 @@
             "named": true
           }
         ]
+      },
+      "rest": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ".",
+            "named": false
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
       }
     },
     "children": {
@@ -4835,7 +4804,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "env",
@@ -4866,6 +4835,10 @@
       "types": [
         {
           "type": "cell_path",
+          "named": true
+        },
+        {
+          "type": "identifier",
           "named": true
         }
       ]


### PR DESCRIPTION
Fix #60 

This PR changes the syntax tree of list destrcture pattern.

Before this change, only `[$x ..$y]` is supported as list destrcture pattern.
However, there are various cases (e.g. `[1 ..$x]`, [$x $y ..]).
To support other various cases, this PR changes the way of parsing list destrcture pattern.

Before this change, parsing list destrcture pattern generates different syntax tree from list pattern.
For example, when parsing `match $xs {[$x ..$y] => {}}`, `(val_list)` and `(val_variable)` nodes were not generated under `(match_pattern)` node before this change as follows.

```
(nu_script
  (pipeline
    (pipe_element
      (ctrl_match
        (val_variable
          (identifier))
        (match_arm
          (match_pattern
            (identifier) ; <-- (val_list) and (val_variable) are not generated
            (identifier))
          (block))))))
```

After this change, the parsing is done without distinguishing between list destrcture patten and list pattern.
`(val_list)` and `(val_variable)` nodes are also generated when parsing list destrcture pattern as follows.

```
(nu_script
  (pipeline
    (pipe_element
      (ctrl_match
        (val_variable
          (identifier))
        (match_arm
          (match_pattern
            (val_list
              (val_variable
                (identifier))
              (val_variable
                (identifier))))
          (block))))))
```