### PR TITLE
Fix pasing of match pattern

### DIFF
--- a/corpus/ctrl/match.nu
+++ b/corpus/ctrl/match.nu
@@ -274,3 +274,45 @@ match foo {
           (match_pattern
             (val_string))
           (block))))))
+
+=====
+match-008-record
+=====
+
+match $x {
+  {$y} => {}
+  {$foo, $bar} => {}
+  {$a, b: c} => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (val_record
+              (val_variable
+                (identifier))))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_record
+              (val_variable
+                (identifier))
+              (val_variable
+                (identifier))))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_record
+              (val_variable
+                (identifier))
+              (record_entry
+                  (identifier)
+                  (val_string))))
+          (block))))))

--- a/corpus/ctrl/match.nu
+++ b/corpus/ctrl/match.nu
@@ -254,3 +254,23 @@ match $xs {
           (block))
         (default_arm
           (block))))))
+
+=====
+match-007-unquoted
+=====
+
+match foo {
+   foo => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_string)
+        (match_arm
+          (match_pattern
+            (val_string))
+          (block))))))

--- a/grammar.js
+++ b/grammar.js
@@ -30,6 +30,8 @@ module.exports = grammar({
     [$._match_pattern_value, $._value],
     [$._match_pattern_expression, $._list_item_expression],
     [$._match_pattern_list, $.val_list],
+    [$._match_pattern_record, $.val_record],
+    [$._match_pattern_record_variable, $._value],
   ],
 
   rules: {
@@ -434,7 +436,7 @@ module.exports = grammar({
         $.val_string,
         $.val_date,
         alias($._match_pattern_list, $.val_list),
-        $.val_record,
+        alias($._match_pattern_record, $.val_record),
         $.val_table,
       ),
 
@@ -477,6 +479,17 @@ module.exports = grammar({
 
     _match_pattern_ignore_rest: ($) =>
       seq(PUNC().dot, token.immediate(PUNC().dot)),
+
+    _match_pattern_record: ($) =>
+      seq(
+        BRACK().open_brace,
+        repeat(field("entry", choice($.record_entry, $._match_pattern_record_variable))),
+        BRACK().close_brace,
+        optional($.cell_path),
+      ),
+
+    _match_pattern_record_variable: ($) =>
+      seq($.val_variable, optional(PUNC().comma)),
 
     ctrl_try: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -483,7 +483,12 @@ module.exports = grammar({
     _match_pattern_record: ($) =>
       seq(
         BRACK().open_brace,
-        repeat(field("entry", choice($.record_entry, $._match_pattern_record_variable))),
+        repeat(
+          field(
+            "entry",
+            choice($.record_entry, $._match_pattern_record_variable),
+          ),
+        ),
         BRACK().close_brace,
         optional($.cell_path),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -375,7 +375,10 @@ module.exports = grammar({
     ctrl_match: ($) =>
       seq(
         KEYWORD().match,
-        field("scrutinee", $._expression),
+        field(
+          "scrutinee",
+          choice($._expression, alias($.unquoted, $.val_string)),
+        ),
         BRACK().open_brace,
         repeat($.match_arm),
         optional($.default_arm),
@@ -402,12 +405,12 @@ module.exports = grammar({
 
     match_pattern: ($) =>
       choice(
-        seq($._match_pattern_expression, optional($.match_guard)),
-        seq(
-          $._match_pattern_expression,
-          repeat(seq(PUNC().pipe, $._match_pattern_expression)),
-        ),
+        seq($._match_pattern, optional($.match_guard)),
+        seq($._match_pattern, repeat(seq(PUNC().pipe, $._match_pattern))),
       ),
+
+    _match_pattern: ($) =>
+      choice($._match_pattern_expression, alias($.unquoted, $.val_string)),
 
     match_guard: ($) => seq(KEYWORD().if, $._expression),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3062,8 +3062,22 @@
           "type": "FIELD",
           "name": "scrutinee",
           "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "unquoted"
+                },
+                "named": true,
+                "value": "val_string"
+              }
+            ]
           }
         },
         {
@@ -3194,7 +3208,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_match_pattern_expression"
+              "name": "_match_pattern"
             },
             {
               "type": "CHOICE",
@@ -3215,7 +3229,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_match_pattern_expression"
+              "name": "_match_pattern"
             },
             {
               "type": "REPEAT",
@@ -3228,12 +3242,30 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "_match_pattern_expression"
+                    "name": "_match_pattern"
                   }
                 ]
               }
             }
           ]
+        }
+      ]
+    },
+    "_match_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_match_pattern_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "unquoted"
+          },
+          "named": true,
+          "value": "val_string"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3357,8 +3357,13 @@
           "value": "val_list"
         },
         {
-          "type": "SYMBOL",
-          "name": "val_record"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_match_pattern_record"
+          },
+          "named": true,
+          "value": "val_record"
         },
         {
           "type": "SYMBOL",
@@ -3523,6 +3528,72 @@
             "type": "STRING",
             "value": "."
           }
+        }
+      ]
+    },
+    "_match_pattern_record": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "FIELD",
+            "name": "entry",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "record_entry"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_match_pattern_record_variable"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "cell_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_match_pattern_record_variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "val_variable"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -11291,6 +11362,14 @@
     [
       "_match_pattern_list",
       "val_list"
+    ],
+    [
+      "_match_pattern_record",
+      "val_record"
+    ],
+    [
+      "_match_pattern_record_variable",
+      "_value"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4731,7 +4731,15 @@
         "required": false,
         "types": [
           {
+            "type": ",",
+            "named": false
+          },
+          {
             "type": "record_entry",
+            "named": true
+          },
+          {
+            "type": "val_variable",
             "named": true
           }
         ]


### PR DESCRIPTION
Fix to correctly parse following two match patterns
- a short-hand of record pattern (e.g. `{$key}`)
- unquoted string