### PR TITLE
Indent modifications

### DIFF
--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -10,9 +10,6 @@
   (block)
 ] @indent.begin
 
-(("|") @indent.begin
-  (#set! indent.immediate 1))
-
 [
   "}"
   "]"

--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -8,6 +8,9 @@
   (block)
 ] @indent.begin
 
+(("|") @indent.begin
+  (#set! indent.immediate 1))
+
 [
   "}"
   "]"

--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -1,6 +1,4 @@
 [
-  (pipeline)
-  (pipe_element)
   (expr_parenthesized)
   (parameter_bracks)
   (val_record)

--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -2,6 +2,7 @@
   (pipeline)
   (pipe_element)
   (expr_parenthesized)
+  (parameter_bracks)
   (val_record)
   (val_list)
   (val_closure)

--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -1,10 +1,12 @@
 [
   (expr_parenthesized)
   (parameter_bracks)
+
   (val_record)
   (val_list)
   (val_closure)
   (val_table)
+
   (block)
 ] @indent.begin
 


### PR DESCRIPTION
### Brief Description
Fixes indentation issues for function parameters & pipes stacking indentation. Also provides an alternative indentation to pipes.

### Fix Details
#### Indentation for function parameters.
There was no indentation provided for function parameters within the [] block. Examples
- before:
```nu
export def function_name [
parameter: type   # Documentation
optional?: type   # Documentation
]: [string -> table] {
```
- now:
```nu
export def function_name [
    parameter: type   # Documentation
    optional?: type   # Documentation
]: [string -> table] {
```

#### Pipe stacking indentation.
Sometimes pipes nodes can stack on each other on double (triple & so on) the indentation. This generally happens in this pattern:
```nu
{
    cmd
} {
        cmd
    }

```
This would probably occur most commonly in this scenario:
```nu
if true {
    cmd
} else {
        cmd
    }
```
There isn't a straight forward fix to this, so it goes towards opinionated territory.
What I've done is remove pipeline indentation alltogether. This fixes the issue & I've seen only 1 place where the behaviour changes. Normally if you do a command at the start of a line, if you go to the next line you will automatically indent. This is because even a command at the start is consider a pipeline. I view this as a positive effect. However it would also remove indentation for the next line in cases you have a pipe at the end of the line.

That being said I think the indentation provided by (pipeline) nodes overall does more damage than provide convenience, so I think the best course of action is to simply remove its indentation effect & try and replicate it via other methods(the method I attempted is provided below).

### Proposed change
Adding @indent.immediate to "|" for pipeline indentation. This creates python line indentation if you have an open pipe "|" at the end of the line. This approach works well with 2 caveats:
- comments in the middle of a pipe destroy the indent level:
```nu
cmd |
    properly_indented_command |
# comment kills indentation
imporperly_indented_command
```
- indent persist until a command is inputed on a line. If you enter empty lines the indent would be preserved until you input a command:
```nu
cmd |
    proper_indent |


    another_command
```
the above code is not valid syntax, as a naked pipe requires a command on the very next line (or a comment line). I view this as a minor issue, as even if the indent was not there if someone enters a couple of empty lines and then a command after a naken pipe it would still be invalid syntax. So it is an indent issue only when someone is writing invalid code in the first place.

In short, this approach gives you proper indent after naked pipes at the cost of breaking indentation within a pipeline if you use **non-inline** comments in the middle of a pipe.

### Help required.
Someone should test the indentation file in helix. I personally wasn't able to get the indents.scm file to have any change in helix to properly test it.
