### PR TITLE
Fix parsing of record & list bodies.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1084,38 +1084,27 @@ module.exports = grammar({
         BRACK().open_brack,
         optional(
           seq(
-            repeat(
-              seq(
-                field(
-                  "item",
-                  choice(
-                    $._list_item_expression,
-                    alias($._unquoted_in_list, $.val_string),
-                    alias($.short_flag, $.val_string),
-                    alias($.long_flag, $.val_string),
-                    alias($._list_item_starts_with_sign, $.val_string),
-                  ),
-                ),
-                $._entry_separator,
-              ),
-            ),
-            seq(
-              field(
-                "item",
-                choice(
-                  $._list_item_expression,
-                  alias($._unquoted_in_list, $.val_string),
-                  alias($.short_flag, $.val_string),
-                  alias($.long_flag, $.val_string),
-                  alias($._list_item_starts_with_sign, $.val_string),
-                ),
-              ),
-              optional($._entry_separator),
-            ),
+            repeat(seq($.val_entry, $._entry_separator)),
+            seq($.val_entry, optional($._entry_separator)),
           ),
         ),
         BRACK().close_brack,
         optional($.cell_path),
+      ),
+
+    val_entry: ($) =>
+      prec(
+        10,
+        field(
+          "item",
+          choice(
+            $._list_item_expression,
+            alias($._unquoted_in_list, $.val_string),
+            alias($.short_flag, $.val_string),
+            alias($.long_flag, $.val_string),
+            alias($._list_item_starts_with_sign, $.val_string),
+          ),
+        ),
       ),
 
     _list_item_expression: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,5 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
 module.exports = grammar({
   name: "nu",
 
@@ -1116,7 +1118,17 @@ module.exports = grammar({
     val_record: ($) =>
       seq(
         BRACK().open_brace,
-        repeat(field("entry", $.record_entry)),
+        seq(
+          optional(
+            repeat(
+              seq(field("entry", $.record_entry), $.record_entry_separator),
+            ),
+          ),
+          seq(
+            field("entry", $.record_entry),
+            optional($.record_entry_separator),
+          ),
+        ),
         BRACK().close_brace,
         optional($.cell_path),
       ),
@@ -1147,8 +1159,9 @@ module.exports = grammar({
             alias($.cmd_identifier, $.val_string),
           ),
         ),
-        optional(PUNC().comma),
       ),
+
+    record_entry_separator: (_$) => choice(PUNC().comma, /\s/, /[\r\n]/),
 
     _record_key: ($) =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1121,17 +1121,19 @@ module.exports = grammar({
         seq(
           optional(
             repeat(
-              seq(field("entry", $.record_entry), $.record_entry_separator),
+              seq(field("entry", $.record_entry), $._record_entry_separator),
             ),
           ),
           seq(
             field("entry", $.record_entry),
-            optional($.record_entry_separator),
+            optional($._record_entry_separator),
           ),
         ),
         BRACK().close_brace,
         optional($.cell_path),
       ),
+
+    _record_entry_separator: (_$) => choice(PUNC().comma, /\s/, /[\r\n]/),
 
     record_entry: ($) =>
       seq(
@@ -1160,8 +1162,6 @@ module.exports = grammar({
           ),
         ),
       ),
-
-    record_entry_separator: (_$) => choice(PUNC().comma, /\s/, /[\r\n]/),
 
     _record_key: ($) =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1136,7 +1136,8 @@ module.exports = grammar({
         optional($.cell_path),
       ),
 
-    _entry_separator: (_$) => prec(-69, choice(PUNC().comma, /\s/, /[\r\n]/)),
+    _entry_separator: (_$) =>
+      prec(20, token(choice(PUNC().comma, /\s/, /[\r\n]/))),
 
     record_entry: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1082,18 +1082,35 @@ module.exports = grammar({
     val_list: ($) =>
       seq(
         BRACK().open_brack,
-        repeat(
-          field(
-            "item",
-            seq(
-              choice(
-                $._list_item_expression,
-                alias($._unquoted_in_list, $.val_string),
-                alias($.short_flag, $.val_string),
-                alias($.long_flag, $.val_string),
-                alias($._list_item_starts_with_sign, $.val_string),
+        optional(
+          seq(
+            repeat(
+              seq(
+                field(
+                  "item",
+                  choice(
+                    $._list_item_expression,
+                    alias($._unquoted_in_list, $.val_string),
+                    alias($.short_flag, $.val_string),
+                    alias($.long_flag, $.val_string),
+                    alias($._list_item_starts_with_sign, $.val_string),
+                  ),
+                ),
+                $._entry_separator,
               ),
-              optional(PUNC().comma),
+            ),
+            seq(
+              field(
+                "item",
+                choice(
+                  $._list_item_expression,
+                  alias($._unquoted_in_list, $.val_string),
+                  alias($.short_flag, $.val_string),
+                  alias($.long_flag, $.val_string),
+                  alias($._list_item_starts_with_sign, $.val_string),
+                ),
+              ),
+              optional($._entry_separator),
             ),
           ),
         ),
@@ -1121,21 +1138,16 @@ module.exports = grammar({
         optional(
           seq(
             optional(
-              repeat(
-                seq(field("entry", $.record_entry), $._record_entry_separator),
-              ),
+              repeat(seq(field("entry", $.record_entry), $._entry_separator)),
             ),
-            seq(
-              field("entry", $.record_entry),
-              optional($._record_entry_separator),
-            ),
+            seq(field("entry", $.record_entry), optional($._entry_separator)),
           ),
         ),
         BRACK().close_brace,
         optional($.cell_path),
       ),
 
-    _record_entry_separator: (_$) => choice(PUNC().comma, /\s/, /[\r\n]/),
+    _entry_separator: (_$) => prec(-69, choice(PUNC().comma, /\s/, /[\r\n]/)),
 
     record_entry: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1118,15 +1118,17 @@ module.exports = grammar({
     val_record: ($) =>
       seq(
         BRACK().open_brace,
-        seq(
-          optional(
-            repeat(
-              seq(field("entry", $.record_entry), $._record_entry_separator),
-            ),
-          ),
+        optional(
           seq(
-            field("entry", $.record_entry),
-            optional($._record_entry_separator),
+            optional(
+              repeat(
+                seq(field("entry", $.record_entry), $._record_entry_separator),
+              ),
+            ),
+            seq(
+              field("entry", $.record_entry),
+              optional($._record_entry_separator),
+            ),
           ),
         ),
         BRACK().close_brace,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9321,73 +9321,16 @@
           "value": "["
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "FIELD",
-            "name": "item",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_list_item_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_unquoted_in_list"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "short_flag"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "long_flag"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_list_item_starts_with_sign"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "list_body"
+            },
+            {
+              "type": "BLANK"
             }
-          }
+          ]
         },
         {
           "type": "STRING",
@@ -9406,6 +9349,113 @@
           ]
         }
       ]
+    },
+    "list_body": {
+      "type": "PREC",
+      "value": 20,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "entry",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "val_entry"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_entry_separator"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "entry",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "val_entry"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_entry_separator"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "val_entry": {
+      "type": "PREC",
+      "value": 10,
+      "content": {
+        "type": "FIELD",
+        "name": "item",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_list_item_expression"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_unquoted_in_list"
+              },
+              "named": true,
+              "value": "val_string"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "short_flag"
+              },
+              "named": true,
+              "value": "val_string"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "long_flag"
+              },
+              "named": true,
+              "value": "val_string"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_list_item_starts_with_sign"
+              },
+              "named": true,
+              "value": "val_string"
+            }
+          ]
+        }
+      }
     },
     "_list_item_expression": {
       "type": "CHOICE",
@@ -9472,15 +9522,16 @@
           "value": "{"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "FIELD",
-            "name": "entry",
-            "content": {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "SYMBOL",
-              "name": "record_entry"
+              "name": "record_body"
+            },
+            {
+              "type": "BLANK"
             }
-          }
+          ]
         },
         {
           "type": "STRING",
@@ -9499,6 +9550,84 @@
           ]
         }
       ]
+    },
+    "record_body": {
+      "type": "PREC",
+      "value": 20,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "entry",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "record_entry"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_entry_separator"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "entry",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "record_entry"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_entry_separator"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_entry_separator": {
+      "type": "PREC",
+      "value": 20,
+      "content": {
+        "type": "TOKEN",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\s"
+            },
+            {
+              "type": "PATTERN",
+              "value": "[\\r\\n]"
+            }
+          ]
+        }
+      }
     },
     "record_entry": {
       "type": "SEQ",
@@ -9908,18 +10037,6 @@
               }
             ]
           }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2520,6 +2520,22 @@
     }
   },
   {
+    "type": "list_body",
+    "named": true,
+    "fields": {
+      "entry": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "val_entry",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "list_type",
     "named": true,
     "fields": {
@@ -3589,6 +3605,22 @@
     }
   },
   {
+    "type": "record_body",
+    "named": true,
+    "fields": {
+      "entry": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "record_entry",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "record_entry",
     "named": true,
     "fields": {
@@ -4285,6 +4317,86 @@
     }
   },
   {
+    "type": "val_entry",
+    "named": true,
+    "fields": {
+      "item": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "expr_unary",
+            "named": true
+          },
+          {
+            "type": "val_binary",
+            "named": true
+          },
+          {
+            "type": "val_bool",
+            "named": true
+          },
+          {
+            "type": "val_closure",
+            "named": true
+          },
+          {
+            "type": "val_date",
+            "named": true
+          },
+          {
+            "type": "val_duration",
+            "named": true
+          },
+          {
+            "type": "val_filesize",
+            "named": true
+          },
+          {
+            "type": "val_interpolated",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_nothing",
+            "named": true
+          },
+          {
+            "type": "val_number",
+            "named": true
+          },
+          {
+            "type": "val_range",
+            "named": true
+          },
+          {
+            "type": "val_record",
+            "named": true
+          },
+          {
+            "type": "val_string",
+            "named": true
+          },
+          {
+            "type": "val_table",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "val_filesize",
     "named": true,
     "fields": {
@@ -4373,10 +4485,6 @@
             "named": true
           },
           {
-            "type": "val_closure",
-            "named": true
-          },
-          {
             "type": "val_date",
             "named": true
           },
@@ -4386,10 +4494,6 @@
           },
           {
             "type": "val_filesize",
-            "named": true
-          },
-          {
-            "type": "val_interpolated",
             "named": true
           },
           {
@@ -4442,11 +4546,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
           "type": "cell_path",
+          "named": true
+        },
+        {
+          "type": "list_body",
           "named": true
         }
       ]
@@ -4546,11 +4654,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
           "type": "cell_path",
+          "named": true
+        },
+        {
+          "type": "record_body",
           "named": true
         }
       ]

--- a/test/corpus/decl/export-env.nu
+++ b/test/corpus/decl/export-env.nu
@@ -1,4 +1,16 @@
 =====
+export-env-001-smoke-test
+=====
+
+export-env {}
+
+-----
+
+(nu_script
+  (decl_export
+    (block)))
+
+=====
 export-env-002-with-commands
 =====
 

--- a/test/corpus/decl/export-env.nu
+++ b/test/corpus/decl/export-env.nu
@@ -1,16 +1,4 @@
 =====
-export-env-001-smoke-test
-=====
-
-export-env {}
-
------
-
-(nu_script
-  (decl_export
-    (block)))
-
-=====
 export-env-002-with-commands
 =====
 
@@ -28,9 +16,10 @@ export-env {
           (command
             (cmd_identifier)
             (val_record
-              (record_entry
-                (identifier)
-                (val_string))
-              (record_entry
-                (identifier)
-                (val_string)))))))))
+              (record_body
+                (record_entry
+                  (identifier)
+                  (val_string))
+                (record_entry
+                  (identifier)
+                  (val_string))))))))))

--- a/test/corpus/expr/closure.nu
+++ b/test/corpus/expr/closure.nu
@@ -1,4 +1,163 @@
 =====
+closure-001-basic
+=====
+
+[1, 2] | each {|x| $x + 1 }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable
+                  (identifier))
+                (val_number)))))))))
+
+=====
+closure-002-closure-without-parameter
+=====
+
+[1, 2, 3] | each {|| $in + 2 }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes)
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable)
+                (val_number)))))))))
+
+=====
+closure-003-closure-without-parameter-pipes
+=====
+
+[1, 2] | each {
+  $in * 2
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable)
+                (val_number)))))))))
+
+=====
+closure-004-cmd-args
+=====
+
+custom-cmd {|| 'hello' } { 'world' }
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_closure
+          (parameter_pipes)
+          (pipeline
+            (pipe_element
+              (val_string))))
+        (val_closure
+          (pipeline
+            (pipe_element
+              (val_string))))))))
+
+=====
+closure-005-let
+=====
+
+let cl = {
+  'closure'
+}
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_closure
+          (pipeline
+            (pipe_element
+              (val_string))))))))
+
+=====
+closure-006-let-parameter-pipes
+=====
+
+let cl = {|x|
+  $x * 3
+}
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable
+                  (identifier))
+                (val_number)))))))))
+
+=====
 closure-007-record-value
 =====
 

--- a/test/corpus/expr/closure.nu
+++ b/test/corpus/expr/closure.nu
@@ -191,3 +191,31 @@ closure-007-record-value
               (pipeline
                 (pipe_element
                   (val_string))))))))))
+
+=====
+closure-008-while
+=====
+
+let cl = {
+  while $condition {
+    echo hello
+  }
+}
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_closure
+          (ctrl_while
+            (val_variable
+              (identifier))
+            (block
+              (pipeline
+                (pipe_element
+                  (command
+                    (cmd_identifier)
+                    (val_string)))))))))))

--- a/test/corpus/expr/closure.nu
+++ b/test/corpus/expr/closure.nu
@@ -1,154 +1,4 @@
 =====
-closure-001-basic
-=====
-
-[1, 2] | each {|x| $x + 1 }
-
------
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (val_list
-        (val_number)
-        (val_number)))
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_closure
-          (parameter_pipes
-            (parameter
-              (identifier)))
-          (pipeline
-            (pipe_element
-              (expr_binary
-                (val_variable
-                  (identifier))
-                (val_number)))))))))
-
-=====
-closure-002-closure-without-parameter
-=====
-
-[1, 2, 3] | each {|| $in + 2 }
-
------
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (val_list
-        (val_number)
-        (val_number)
-        (val_number)))
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_closure
-          (parameter_pipes)
-          (pipeline
-            (pipe_element
-              (expr_binary
-                (val_variable)
-                (val_number)))))))))
-
-=====
-closure-003-closure-without-parameter-pipes
-=====
-
-[1, 2] | each {
-  $in * 2
-}
-
------
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (val_list
-        (val_number)
-        (val_number)))
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_closure
-          (pipeline
-            (pipe_element
-              (expr_binary
-                (val_variable)
-                (val_number)))))))))
-
-
-=====
-closure-004-cmd-args
-=====
-
-custom-cmd {|| 'hello' } { 'world' }
-
------
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_closure
-          (parameter_pipes)
-          (pipeline
-            (pipe_element
-              (val_string))))
-        (val_closure
-          (pipeline
-            (pipe_element
-              (val_string))))))))
-
-=====
-closure-005-let
-=====
-
-let cl = {
-  'closure'
-}
-
------
-
-(nu_script
-  (stmt_let
-    (identifier)
-    (pipeline
-      (pipe_element
-        (val_closure
-          (pipeline
-            (pipe_element
-              (val_string))))))))
-
-=====
-closure-006-let-parameter-pipes
-=====
-
-let cl = {|x|
-  $x * 3
-}
-
------
-
-(nu_script
-  (stmt_let
-    (identifier)
-    (pipeline
-      (pipe_element
-        (val_closure
-        (parameter_pipes
-          (parameter
-            (identifier)))
-          (pipeline
-            (pipe_element
-              (expr_binary
-                (val_variable
-                  (identifier))
-                (val_number)))))))))
-
-=====
 closure-007-record-value
 =====
 
@@ -163,49 +13,22 @@ closure-007-record-value
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (identifier)
-          (val_closure
-            (parameter_pipes
-              (parameter
-                (identifier)))
-            (pipeline
-              (pipe_element
-                (expr_binary
-                  (val_variable
-                    (identifier))
-                  (val_number))))))
-        (record_entry
-          (identifier)
-          (val_closure
-            (pipeline
-              (pipe_element
-                (val_string)))))))))
-
-=====
-closure-008-while
-=====
-
-let cl = {
-  while $condition {
-    echo hello
-  }
-}
-
------
-
-(nu_script
-  (stmt_let
-    (identifier)
-    (pipeline
-      (pipe_element
-        (val_closure
-          (ctrl_while
-            (val_variable
-              (identifier))
-            (block
+        (record_body
+          (record_entry
+            (identifier)
+            (val_closure
+              (parameter_pipes
+                (parameter
+                  (identifier)))
               (pipeline
                 (pipe_element
-                  (command
-                    (cmd_identifier)
-                    (val_string)))))))))))
+                  (expr_binary
+                    (val_variable
+                      (identifier))
+                    (val_number))))))
+          (record_entry
+            (identifier)
+            (val_closure
+              (pipeline
+                (pipe_element
+                  (val_string))))))))))

--- a/test/corpus/expr/list.nu
+++ b/test/corpus/expr/list.nu
@@ -18,13 +18,21 @@ list-001-item-string
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-002-unquoted-starts-with-numeric
@@ -46,13 +54,21 @@ list-002-unquoted-starts-with-numeric
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-003-unquoted-arithmetic-operator
@@ -75,14 +91,23 @@ list-003-unquoted-arithmetic-operator
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-004-unquoted-comparison-operator
@@ -103,12 +128,19 @@ list-004-unquoted-comparison-operator
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-005-unquoted-regex-operator
@@ -125,8 +157,11 @@ list-005-unquoted-regex-operator
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-006-unquoted-assignment-operator
@@ -146,11 +181,17 @@ list-006-unquoted-assignment-operator
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-007-unquoted-range-operator
@@ -168,9 +209,13 @@ list-007-unquoted-range-operator
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))
 
 =====
 list-008-separated-by-comma
@@ -184,9 +229,13 @@ list-008-separated-by-comma
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_number)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_number)))))))
 
 =====
 list-009-unquoted-path
@@ -210,12 +259,22 @@ list-009-unquoted-path
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)
-        (val_string)))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))))

--- a/test/corpus/expr/range.nu
+++ b/test/corpus/expr/range.nu
@@ -53,33 +53,43 @@ range-002-float-exponent
   (pipeline
     (pipe_element
       (val_list
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))
-        (val_range
-          (val_number)
-          (val_number))))))
+        (list_body
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number)))
+          (val_entry
+            (val_range
+              (val_number)
+              (val_number))))))))
 
 =====
 range-003-only-start
@@ -95,20 +105,20 @@ range-003-only-start
 (nu_script
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number)))))
+      (val_range
+        (val_number)))))
 
 =====
 range-004-only-end
@@ -129,40 +139,40 @@ range-004-only-end
 (nu_script
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number))))
+      (val_range
+        (val_number))))
   (pipeline
     (pipe_element
-        (val_range
-          (val_number)))))
+      (val_range
+        (val_number)))))
 
 =====
 range-005-variable
@@ -714,10 +724,13 @@ range ($n + 1)..($n + 3)..=([$a $b] | math max)
             (pipeline
               (pipe_element
                 (val_list
-                  (val_variable
-                    (identifier))
-                  (val_variable
-                    (identifier))))
+                  (list_body
+                    (val_entry
+                      (val_variable
+                        (identifier)))
+                    (val_entry
+                      (val_variable
+                        (identifier))))))
               (pipe_element
                 (command
                   (cmd_identifier)
@@ -803,10 +816,13 @@ range ..($n + 3)..=([$a $b] | math max)
             (pipeline
               (pipe_element
                 (val_list
-                  (val_variable
-                    (identifier))
-                  (val_variable
-                    (identifier))))
+                  (list_body
+                    (val_entry
+                      (val_variable
+                        (identifier)))
+                    (val_entry
+                      (val_variable
+                        (identifier))))))
               (pipe_element
                 (command
                   (cmd_identifier)

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -222,3 +222,25 @@ record-009-duration
                 (record_entry
                   (identifier)
                   (val_string))))))))))
+
+=====
+record-010-key-value-seperation
+=====
+
+{
+    export: 556key: 897
+}
+
+-----
+
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (ERROR
+              (identifier))
+            (val_number)))))))

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -10,9 +10,10 @@ record-001-basic
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (val_string)
-          (val_string))))))
+        (record_body
+          (record_entry
+            (val_string)
+            (val_string)))))))
 
 =====
 record-002-empty
@@ -43,15 +44,16 @@ record-003-number-key
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (val_number)
-          (val_string))
-        (record_entry
-          (val_number)
-          (val_string))
-        (record_entry
-          (val_number)
-          (val_string))))))
+        (record_body
+          (record_entry
+            (val_number)
+            (val_string))
+          (record_entry
+            (val_number)
+            (val_string))
+          (record_entry
+            (val_number)
+            (val_string)))))))
 
 =====
 record-004-key-using-symbol
@@ -71,21 +73,22 @@ record-004-key-using-symbol
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_string))))))
+        (record_body
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string)))))))
 
 =====
 record-005-variable-key
@@ -99,10 +102,11 @@ record-005-variable-key
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (val_variable
-            (identifier))
-          (val_string))))))
+        (record_body
+          (record_entry
+            (val_variable
+              (identifier))
+            (val_string)))))))
 
 =====
 record-006-subexpression-key
@@ -118,19 +122,23 @@ record-006-subexpression-key
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (expr_parenthesized
-            (pipeline
-              (pipe_element
-                (val_list
-                  (val_string)
-                  (val_string)))
-              (pipe_element
-                (command
-                  (cmd_identifier)
-                  (val_string)
-                  (val_string)))))
-          (val_string))))))
+        (record_body
+          (record_entry
+            (expr_parenthesized
+              (pipeline
+                (pipe_element
+                  (val_list
+                    (list_body
+                      (val_entry
+                        (val_string))
+                      (val_entry
+                        (val_string)))))
+                (pipe_element
+                  (command
+                    (cmd_identifier)
+                    (val_string)
+                    (val_string)))))
+            (val_string)))))))
 
 =====
 record-007-keyword-key
@@ -147,15 +155,17 @@ record-007-keyword-key
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_record
-            (record_entry
-              (identifier)
-              (val_string))))))))
+        (record_body
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_record
+              (record_body
+                (record_entry
+                  (identifier)
+                  (val_string))))))))))
 
 =====
 record-008-modifier-key
@@ -172,12 +182,43 @@ record-008-modifier-key
   (pipeline
     (pipe_element
       (val_record
-        (record_entry
-          (identifier)
-          (val_string))
-        (record_entry
-          (identifier)
-          (val_record
-            (record_entry
-              (identifier)
-              (val_string))))))))
+        (record_body
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_record
+              (record_body
+                (record_entry
+                  (identifier)
+                  (val_string))))))))))
+
+=====
+record-009-duration
+=====
+
+{
+    export: 5sec,
+    use: {export: value},
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_duration
+              (val_number)
+              (duration_unit)))
+          (record_entry
+            (identifier)
+            (val_record
+              (record_body
+                (record_entry
+                  (identifier)
+                  (val_string))))))))))

--- a/test/corpus/expr/subexpr.nu
+++ b/test/corpus/expr/subexpr.nu
@@ -201,9 +201,13 @@ subexpr-009-closure
         (pipeline
           (pipe_element
             (val_list
-              (val_number)
-              (val_number)
-              (val_number)))
+              (list_body
+                (val_entry
+                  (val_number))
+                (val_entry
+                  (val_number))
+                (val_entry
+                  (val_number)))))
           (pipe_element
             (command
               (cmd_identifier)

--- a/test/corpus/expr/values.nu
+++ b/test/corpus/expr/values.nu
@@ -10,17 +10,29 @@ values-001-numbers
   (pipeline
     (pipe_element
       (val_list
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)))))
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))))
 
 =====
 values-002-booleans
@@ -35,13 +47,17 @@ values-002-booleans
   (pipeline
     (pipe_element
       (val_list
-        (val_bool)
-        (val_bool)
-        (expr_parenthesized
-          (pipeline
-            (pipe_element
-              (expr_unary
-                (val_bool)))))))))
+        (list_body
+          (val_entry
+            (val_bool))
+          (val_entry
+            (val_bool))
+          (val_entry
+            (expr_parenthesized
+              (pipeline
+                (pipe_element
+                  (expr_unary
+                    (val_bool)))))))))))
 
 =====
 values-003-nothing
@@ -58,8 +74,11 @@ values-003-nothing
   (pipeline
     (pipe_element
       (val_list
-        (val_nothing)
-        (val_nothing)))))
+        (list_body
+          (val_entry
+            (val_nothing))
+          (val_entry
+            (val_nothing)))))))
 
 =====
 values-004-binary
@@ -103,12 +122,19 @@ values-005-numbers-with-underscore
   (pipeline
     (pipe_element
       (val_list
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)))))
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))))
 
 =====
 values-006-infinity-number
@@ -133,16 +159,27 @@ values-006-infinity-number
   (pipeline
     (pipe_element
       (val_list
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)))))
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))))
 
 =====
 values-006-not-a-number
@@ -161,7 +198,12 @@ values-006-not-a-number
   (pipeline
     (pipe_element
       (val_list
-        (val_number)
-        (val_number)
-        (val_number)
-        (val_number)))))
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))))

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -258,8 +258,7 @@ cargo install --path ./dir
         (cmd_identifier)
         (val_string)
         (long_flag)
-        (val_string))))
-  )
+        (val_string)))))
 
 ======
 cmd-012-path-string-2-dots
@@ -286,8 +285,7 @@ cd ../dir
     (pipe_element
       (command
         (cmd_identifier)
-        (val_string))))
-  )
+        (val_string)))))
 
 ======
 cmd-013-path-string-3-dots
@@ -314,8 +312,7 @@ cd .../dir
     (pipe_element
       (command
         (cmd_identifier)
-        (val_string))))
-  )
+        (val_string)))))
 
 ======
 cmd-014-path-string-4-dots
@@ -342,8 +339,7 @@ cd ..../dir
     (pipe_element
       (command
         (cmd_identifier)
-        (val_string))))
-  )
+        (val_string)))))
 
 ======
 cmd-015-unquoted-starts-with-numeric
@@ -436,8 +432,11 @@ echo [hello,world]
       (command
         (cmd_identifier)
         (val_list
-          (val_string)
-          (val_string))))))
+          (list_body
+            (val_entry
+              (val_string))
+            (val_entry
+              (val_string))))))))
 
 ======
 cmd-017-string-external

--- a/test/corpus/pipe/pipe.nu
+++ b/test/corpus/pipe/pipe.nu
@@ -177,12 +177,18 @@ match $x {
           (match_pattern
             (val_number))
           (val_list
-            (val_number)))
+            (list_body
+              (val_entry
+                (val_number)))))
         (default_arm
           (val_list
-            (val_number)
-            (val_number)
-            (val_number)))))
+            (list_body
+              (val_entry
+                (val_number))
+              (val_entry
+                (val_number))
+              (val_entry
+                (val_number)))))))
     (pipe_element
       (command
         (cmd_identifier)
@@ -220,13 +226,18 @@ if $cond {
           (pipeline
             (pipe_element
               (val_list
-                (val_number)))))
+                (list_body
+                  (val_entry
+                    (val_number)))))))
         (block
           (pipeline
             (pipe_element
               (val_list
-                (val_number)
-                (val_number)))))))
+                (list_body
+                  (val_entry
+                    (val_number))
+                  (val_entry
+                    (val_number)))))))))
     (pipe_element
       (command
         (cmd_identifier)
@@ -258,7 +269,9 @@ do { [1] }
           (pipeline
             (pipe_element
               (val_list
-                (val_number)))))))
+                (list_body
+                  (val_entry
+                    (val_number)))))))))
     (pipe_element
       (command
         (cmd_identifier)
@@ -292,7 +305,9 @@ try {
           (pipeline
             (pipe_element
               (val_list
-                (val_number)))))))
+                (list_body
+                  (val_entry
+                    (val_number)))))))))
     (pipe_element
       (command
         (cmd_identifier)
@@ -328,13 +343,18 @@ try {
           (pipeline
             (pipe_element
               (val_list
-                (val_number)))))
+                (list_body
+                  (val_entry
+                    (val_number)))))))
         (block
           (pipeline
             (pipe_element
               (val_list
-                (val_number)
-                (val_number)))))))
+                (list_body
+                  (val_entry
+                    (val_number))
+                  (val_entry
+                    (val_number)))))))))
     (pipe_element
       (command
         (cmd_identifier)
@@ -362,8 +382,11 @@ pipe-012-next-line-after-value
   (pipeline
     (pipe_element
       (val_list
-        (val_number)
-        (val_number)))
+        (list_body
+          (val_entry
+            (val_number))
+          (val_entry
+            (val_number)))))
     (pipe_element
       (command
         (cmd_identifier)))))
@@ -420,7 +443,9 @@ do { [1] } |
           (pipeline
             (pipe_element
               (val_list
-                (val_number)))))))
+                (list_body
+                  (val_entry
+                    (val_number)))))))))
     (pipe_element
       (command
         (cmd_identifier)

--- a/test/corpus/pipe/where.nu
+++ b/test/corpus/pipe/where.nu
@@ -11,12 +11,12 @@ ls | where size > 10kb
     (pipe_element
       (command
         (cmd_identifier)))
-      (pipe_element
-        (where_command
-          (val_string)
-          (val_filesize
-            (val_number)
-            (filesize_unit))))))
+    (pipe_element
+      (where_command
+        (val_string)
+        (val_filesize
+          (val_number)
+          (filesize_unit))))))
 
 =====
 where-002-parenthesized
@@ -30,20 +30,23 @@ where-002-parenthesized
   (pipeline
     (pipe_element
       (val_list
-        (val_string)
-        (val_string)))
-      (pipe_element
-        (where_command
-          (expr_parenthesized
-            (pipeline
-              (pipe_element
-                (val_variable
-                  (identifier)))
-              (pipe_element
-                (command
-                  (cmd_identifier)
-                  (val_string)
-                  (val_string)))))))))
+        (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string)))))
+    (pipe_element
+      (where_command
+        (expr_parenthesized
+          (pipeline
+            (pipe_element
+              (val_variable
+                (identifier)))
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_string)
+                (val_string)))))))))
 
 =====
 where-003-closure
@@ -58,19 +61,19 @@ ls | where {|x| $x.size > 10kb }
     (pipe_element
       (command
         (cmd_identifier)))
-      (pipe_element
-        (where_command
-          (val_closure
-            (parameter_pipes
-              (parameter
-                (identifier)))
-            (pipeline
-              (pipe_element
-                (expr_binary
-                  (val_variable
-                    (identifier)
-                    (cell_path
-                      (path)))
-                  (val_filesize
-                    (val_number)
-                    (filesize_unit))))))))))
+    (pipe_element
+      (where_command
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (expr_binary
+                (val_variable
+                  (identifier)
+                  (cell_path
+                    (path)))
+                (val_filesize
+                  (val_number)
+                  (filesize_unit))))))))))

--- a/test/corpus/stmt/let.nu
+++ b/test/corpus/stmt/let.nu
@@ -48,7 +48,6 @@ let x = 42 | math sin
           (cmd_identifier)
           (val_string))))))
 
-
 =====
 let-004-with-type
 =====
@@ -84,6 +83,7 @@ let x: record<name: string> = { name: 'tree-sitter' }
     (pipeline
       (pipe_element
         (val_record
-          (record_entry
-            (identifier)
-            (val_string)))))))
+          (record_body
+            (record_entry
+              (identifier)
+              (val_string))))))))

--- a/test/corpus/stmt/register.nu
+++ b/test/corpus/stmt/register.nu
@@ -53,14 +53,16 @@ register ~/plugins/nu-plugin-math {
 -----
 
 (nu_script
-      (stmt_register
-        (val_string))
-      (pipeline
-        (pipe_element
-          (val_record
-            (record_entry
-              (val_string)
-              (val_record
+  (stmt_register
+    (val_string))
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (val_string)
+            (val_record
+              (record_body
                 (record_entry
                   (val_string)
                   (val_string))
@@ -79,32 +81,37 @@ register ~/plugins/nu-plugin-math {
                 (record_entry
                   (val_string)
                   (val_list
-                    (val_record
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string)))
-                    (val_record
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string))
-                      (record_entry
-                        (val_string)
-                        (val_string)))))))))))
+                    (list_body
+                      (val_entry
+                        (val_record
+                          (record_body
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string)))))
+                      (val_entry
+                        (val_record
+                          (record_body
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string))
+                            (record_entry
+                              (val_string)
+                              (val_string))))))))))))))))
 
 =====
 register-004-variable


### PR DESCRIPTION
### Brief Description
Change the node structure of the record & list bodies to better represent the actual syntax of the language. This fixes some bugs as well as make the syntax more consistent & easier to read.

### Fixes
- TS can't properly detect durantion values in records. It is instead deteced as integer & a command node that create an error:
```nu
{
    key: 5sec
}
```
- TS can't properly detect when value & key begins & allow invald syntax with value & key having no space or any separator in between. The following example is considered valid by TS:
```nu
{
    key: 1536another_key: 8549
}
```

### What is changed
- Records use a new body structure which manages entries & separators in between. This fixes the separator bugs described above & creates new nodes that can be used for highlighting & indenting.
- Lists also have their structure changed in the same manner (both records & list body acts the same in nushell syntax, with exception to what is actually a record entry ``key: value`` vs a list entry ``value``.
- Record tests are added for the bugs described above. All tests have been updated with the new node syntax.

### Details
- New function is added to grammar js for general body structure. It consist of repeated statement all seperated by a mandotory separator, followed by a final statement with an optional separator.
- This function is applied to the bodies of lists & records with the corresponding entries.
- List has an added node for the list_entry itself (before it was just hardcoded into the list rule)
- Separator is added for entries ``[,\s\n\r]``
- Comment is added on top of the code to improve LSP parsing of code with tsserver (commonly used by other TS projects for grammar.sj)
- Tests are updated with new new node syntax - I've individually checked the diffs of all tests to make sure they are working as indented
- New test has been added to check if records can accept duration input.
- New test has been added to test if records accept invaild input with no separator between value & key.