### PR TITLE
Quickfix for separator token using non-lexical precedence.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1146,7 +1146,7 @@ module.exports = grammar({
     ),
 
     _entry_separator: (_$) =>
-      prec(20, token(choice(PUNC().comma, /\s/, /[\r\n]/))),
+      token(prec(20, choice(PUNC().comma, /\s/, /[\r\n]/))),
 
     record_entry: ($) =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9606,10 +9606,10 @@
       }
     },
     "_entry_separator": {
-      "type": "PREC",
-      "value": 20,
+      "type": "TOKEN",
       "content": {
-        "type": "TOKEN",
+        "type": "PREC",
+        "value": 20,
         "content": {
           "type": "CHOICE",
           "members": [


### PR DESCRIPTION
The separator node introduced in #94 should use lexical precedence instead of parse precedence. This is a quick fix to that.
Currently I don't know any issues introduced by this, but this could potentially create an issue.