### PR TITLE
nvim queries: Conform to commonly used highlight names

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -56,7 +56,7 @@
 
 ;;; ---
 ;;; literals
-(val_number) @constant.numeric
+(val_number) @number
 (val_duration unit: _ @variable.parameter)
 (val_filesize unit: _ @variable.parameter)
 (val_binary
@@ -64,18 +64,20 @@
        "0b"
        "0o"
        "0x"
-    ] @constant.numeric
+    ] @number
     "[" @punctuation.bracket
     digit: [
         "," @punctuation.delimiter
-        (hex_digit) @constant.number
+        (hex_digit) @number
     ]
     "]" @punctuation.bracket
-) @constant.numeric
+) @number
 (val_bool) @constant.builtin
 (val_nothing) @constant.builtin
 (val_string) @string
-(val_date) @constant.number
+arg_str: (val_string) @variable.parameter
+file_path: (val_string) @variable.parameter
+(val_date) @number
 (inter_escape_sequence) @constant.character.escape
 (escape_sequence) @constant.character.escape
 (val_interpolated [
@@ -176,14 +178,14 @@
     "e>"   "err>"
     "e+o>" "err+out>"
     "o+e>" "out+err>"
-] @special
+] @operator
 
 ;;; ---
 ;;; punctuation
 [
     ","
     ";"
-] @punctuation.delimiter
+] @punctuation.special
 
 (param_short_flag "-" @punctuation.delimiter)
 (param_long_flag ["--"] @punctuation.delimiter)
@@ -193,6 +195,7 @@
 (param_value ["="] @punctuation.special)
 (param_cmd ["@"] @punctuation.special)
 (param_opt ["?"] @punctuation.special)
+(returns "->" @punctuation.special)
 
 [
     "(" ")"
@@ -202,6 +205,8 @@
 
 (val_record
   (record_entry ":" @punctuation.delimiter))
+key: (identifier) @property
+
 ;;; ---
 ;;; identifiers
 (param_rest
@@ -234,17 +239,21 @@
 ) @variable.parameter
 
 (val_variable
-  "$" @variable.parameter
+  "$" @punctuation.special
   [
-   (identifier) @namespace
-   "in"
-   "nu"
-   "env"
-   ] @special
-)
+   (identifier) @variable
+   "in" @special
+   "nu" @namespace
+   "env" @constant
+  ]
+) @none
+
+(record_entry
+  ":" @punctuation.special)
+
 ;;; ---
 ;;; types
-(flat_type) @type.builtin
+(flat_type) @type
 (list_type
     "list" @type.enum
     ["<" ">"] @punctuation.bracket
@@ -253,9 +262,17 @@
     ["record" "table"] @type.enum
     "<" @punctuation.bracket
     key: (_) @variable.parameter
-    ["," ":"] @punctuation.delimiter
+    ["," ":"] @punctuation.special
     ">" @punctuation.bracket
 )
 
-(shebang) @comment
+(shebang) @keyword.directive
 (comment) @comment
+(
+ (comment) @comment.documentation
+ (decl_def)
+)
+(
+ (parameter)
+ (comment) @comment.documentation
+)


### PR DESCRIPTION
This updates:

| Query | Highlight name | Like in... |
|-|-|-|
| Punctuation `:`, `,` | `punctuation.special` | TOML, Bash, JSON, ... |
| Key fields in tables/records | `variable.member` | Go, Zig, V, TOML |
| Returns `->` | `punctuation.special` | Rust |
| Variable `$` | `punctuation.special` | Bash, Awk |
| Variable identifier | `variable` | Bash, Awk, Perl, Fish |
| Shebang | `keyword.directive` | Bash, Awk |
| Built-in types | `type` | Zig et al[^1] |
| Numbers | `number` | Zig, Rust, Python, TOML, Bash, ... |
| Arguments | `variable.parameter` |  Bash[^2] |
| Redirect operator | `operator` | Bash, Fish |
| Redirect destination | `variable.parameter` | Bash |

[^1]: Note that for built-in types, languages like Rust, Python, Go differentiates highlights of built-in types and other types (such as structs), but there are no other types in Nu, I'll leave this up to debate, IMO a generic type will suffice here.

[^2]: Perl, Fish and Awk all leave these unhighlighted.

Also adds highlights for documentation comments for functions and parameters.

I've tried to put newly introduced highlight queries into the correct groups in the file, let me know if there are any other prevailing styles I should follow!