### PR TITLE
nvim queries: Highlight built-in commands

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -221,13 +221,40 @@
 (scope_pattern [(wild_card) @function])
 
 (cmd_identifier) @function
+; generated with Nu 0.93.0
+; > help commands
+;   | filter { $in.command_type == builtin and $in.category != core }
+;   | each {$'"($in.name | split row " " | $in.0)"'}
+;   | uniq
+;   | str join ' '
+(command
+  head: [
+    (cmd_identifier) @function.builtin
+    (#any-of? @function.builtin
+     "all" "ansi" "any" "append" "ast" "bits" "bytes" "cal" "cd" "char" "clear"
+     "collect" "columns" "compact" "complete" "config" "cp" "date" "debug"
+     "decode" "default" "detect" "dfr" "drop" "du" "each" "encode" "enumerate"
+     "every" "exec" "exit" "explain" "explore" "export-env" "fill" "filter"
+     "find" "first" "flatten" "fmt" "format" "from" "generate" "get" "glob"
+     "grid" "group" "group-by" "hash" "headers" "histogram" "history" "http"
+     "input" "insert" "inspect" "interleave" "into" "is-empty" "is-not-empty"
+     "is-terminal" "items" "join" "keybindings" "kill" "last" "length"
+     "let-env" "lines" "load-env" "ls" "math" "merge" "metadata" "mkdir"
+     "mktemp" "move" "mv" "nu-check" "nu-highlight" "open" "panic" "par-each"
+     "parse" "path" "plugin" "port" "prepend" "print" "ps" "query" "random"
+     "range" "reduce" "reject" "rename" "reverse" "rm" "roll" "rotate"
+     "run-external" "save" "schema" "select" "seq" "shuffle" "skip" "sleep"
+     "sort" "sort-by" "split" "split-by" "start" "stor" "str" "sys" "table"
+     "take" "tee" "term" "timeit" "to" "touch" "transpose" "tutor" "ulimit"
+     "uname" "uniq" "uniq-by" "update" "upsert" "url" "values" "view" "watch"
+     "where" "which" "whoami" "window" "with-env" "wrap" "zip"
+    )
+  ])
 
 (command
     "^" @punctuation.delimiter
     head: (_) @function
 )
-
-"where" @function
 
 (path
   ["." "?"] @punctuation.delimiter


### PR DESCRIPTION
I thought it'd be great to highlight built-in commands differently to custom commands similar to what Nu does in the prompt line. It should be fairly easy to use the oneliner included in the comments on later versions of Nu to update the list.

Reference:
- Bash: https://github.com/nvim-treesitter/nvim-treesitter/blob/b694628cbe513ae8bcf9fb5ac791a73ca3fd5320/runtime/queries/bash/highlights.scm#L169-L176
- Fish: https://github.com/nvim-treesitter/nvim-treesitter/blob/b694628cbe513ae8bcf9fb5ac791a73ca3fd5320/runtime/queries/fish/highlights.scm#L115-L124

Core built-ins are filtered out because they are already specified higher up in the file as keywords.

All commands that aren't in the list are still highlighted with `@function`