### PR TITLE
Fix highlight of `where` command as builtin

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -261,6 +261,8 @@ key: (identifier) @property
     head: (_) @function
 )
 
+"where" @function.builtin
+
 (path
   ["." "?"] @punctuation.delimiter
 ) @variable.parameter


### PR DESCRIPTION
Apologies, in #100 I hadn't realized the where command is special-cased in the parser and hence requires a separate capture to highlight properly. This ensures the `where` command is also highlighted as built-in.