### PR TITLE
fix: some fixes for use with Neovim

### DIFF
--- a/ftdetect/nu.lua
+++ b/ftdetect/nu.lua
@@ -1,0 +1,1 @@
+vim.filetype.add({ extension = { nu = "nu" } })

--- a/ftplugin/nu.lua
+++ b/ftplugin/nu.lua
@@ -1,0 +1,2 @@
+local bufnr = vim.api.nvim_get_current_buf()
+vim.bo[bufnr].commentstring = "# %s"

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,15 +1,15 @@
-vim.filetype.add({ extension = { nu = "nu" } })
+if vim.g.loaded_tree_sitter_nu then
+  return
+end
+vim.g.loaded_tree_sitter_nu = true
 
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = "nu",
-  callback = function(event) vim.bo[event.buf].commentstring = "# %s" end,
-})
-
-require("nvim-treesitter.parsers").get_parser_configs().nu = {
-  install_info = {
-    url = "https://github.com/nushell/tree-sitter-nu",
-    files = { "src/parser.c" },
-    branch = "main",
-  },
-  filetype = "nu",
-}
+pcall(function()
+  require("nvim-treesitter.parsers").get_parser_configs().nu = {
+    install_info = {
+      url = "https://github.com/nushell/tree-sitter-nu",
+      files = { "src/parser.c" },
+      branch = "main",
+    },
+    filetype = "nu",
+  }
+end)


### PR DESCRIPTION
This PR adds the following fixes for use with Neovim:

- Make sure the `plugin` script can only be sourced once (this is a best practise for plugins).
- Move the registration of the `nu` filetype to an `ftdetect/nu.lua` script, as is common practise for Neovim plugins.
- Move setting the commentstring for `nu` files to `ftplugin/nu.lua` (so there's no need to create an autocommand).
- Make sure the plugin doesn't error if nvim-treesitter isn't installed. This is in preparation for packaging this parser for luarocks.org, so that rocks.nvim/luarocks users can use it without having to install nvim-treesitter.
  See also: #103