### PR TITLE
fix: instructions to install the plugin

### DIFF
--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -12,7 +12,7 @@ Extend your lazy config with treesitter and the nu parser. The parser doesn't ha
     end,
     dependencies = {
         -- NOTE: additional parser
-        { "nushell/tree-sitter-nu" },
+        { "nushell/tree-sitter-nu", build = ":TSUpdate nu" },
     },
     build = ":TSUpdate",
 },


### PR DESCRIPTION
Relates to #107

Technically, this doesn't have to happen on every update to the plugin. But I don't think that lazy has a mechanism to detect only changes to `grammar.js` and `queries/nu/*.scm`

Edit: according to OP of #107, this is the fix.