### PR TITLE
feat: improve distinction of flags and parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ target/
 
 /build/
 
+# C lsp cache
+.ccls-cache/
+
 # Workspace Config
 .nvim/
 # .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
+
+[[package]]
 name = "tree-sitter-nu"
 version = "0.0.1"
 dependencies = [
  "cc",
  "tree-sitter",
+ "tree-sitter-language",
 ]

--- a/grammar.js
+++ b/grammar.js
@@ -1297,16 +1297,17 @@ module.exports = grammar({
         choice(
           OPR().long_flag,
           seq(OPR().long_flag, $.long_flag_identifier),
-          $.long_flag_equals_value
-        )
+          $.long_flag_equals_value,
+        ),
       ),
 
-    long_flag_equals_value: ($) => seq(
-      OPR().long_flag,
-      $.long_flag_identifier,
-      PUNC().eq,
-      $.long_flag_value,
-    ),
+    long_flag_equals_value: ($) =>
+      seq(
+        OPR().long_flag,
+        $.long_flag_identifier,
+        PUNC().eq,
+        $.long_flag_value,
+      ),
 
     long_flag_value: ($) => $._cmd_arg,
 

--- a/grammar.js
+++ b/grammar.js
@@ -7,6 +7,10 @@ module.exports = grammar({
 
   extras: ($) => [/\s/, $.comment],
 
+  // externals: $ => [
+  //   $.long_flag_equals_value
+  // ],
+
   conflicts: ($) => [
     [$._declaration, $._declaration_last],
     [$._declaration_parenthesized, $._declaration_parenthesized_last],
@@ -1264,6 +1268,8 @@ module.exports = grammar({
         field("arg_str", alias($.unquoted, $.val_string)),
       ),
 
+    flag_value: ($) => choice($._value, $.val_string),
+
     redirection: ($) =>
       choice(
         prec.right(
@@ -1288,8 +1294,21 @@ module.exports = grammar({
     long_flag: ($) =>
       prec.right(
         10,
-        choice(OPR().long_flag, seq(OPR().long_flag, $.long_flag_identifier)),
+        choice(
+          OPR().long_flag,
+          seq(OPR().long_flag, $.long_flag_identifier),
+          $.long_flag_equals_value
+        )
       ),
+
+    long_flag_equals_value: ($) => seq(
+      OPR().long_flag,
+      $.long_flag_identifier,
+      PUNC().eq,
+      $.long_flag_value,
+    ),
+
+    long_flag_value: ($) => $._cmd_arg,
 
     unquoted: _unquoted_rule(false),
     _unquoted_in_list: _unquoted_rule(true),

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "test": " ",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "author": "The Nushell Contributors",
   "license": "MIT",

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -75,7 +75,6 @@
 (val_bool) @constant.builtin
 (val_nothing) @constant.builtin
 (val_string) @string
-arg_str: (val_string) @variable.parameter
 file_path: (val_string) @variable.parameter
 (val_date) @number
 (inter_escape_sequence) @constant.character.escape
@@ -189,7 +188,9 @@ file_path: (val_string) @variable.parameter
 
 (param_long_flag ["--"] @punctuation.delimiter)
 (long_flag ["--"] @punctuation.delimiter)
+(long_flag_equals_value ["--"] @punctuation.delimiter)
 (short_flag ["-"] @punctuation.delimiter)
+(long_flag_equals_value ["="] @punctuation.special)
 (param_short_flag ["-"] @punctuation.delimiter)
 (param_rest "..." @punctuation.delimiter)
 (param_type [":"] @punctuation.special)
@@ -222,7 +223,7 @@ key: (identifier) @property
 (param_short_flag (param_short_flag_identifier) @variable.parameter)
 
 (short_flag (short_flag_identifier) @variable.parameter)
-(long_flag (long_flag_identifier) @variable.parameter)
+(long_flag_identifier) @variable.parameter
 
 (scope_pattern [(wild_card) @function])
 

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -74,7 +74,8 @@
 ) @number
 (val_bool) @constant.builtin
 (val_nothing) @constant.builtin
-(val_string) @string
+(val_string) @variable.parameter
+arg_str: (val_string) @variable.parameter
 file_path: (val_string) @variable.parameter
 (val_date) @number
 (inter_escape_sequence) @constant.character.escape
@@ -222,8 +223,8 @@ key: (identifier) @property
 (param_long_flag (long_flag_identifier) @variable.parameter)
 (param_short_flag (param_short_flag_identifier) @variable.parameter)
 
-(short_flag (short_flag_identifier) @variable.parameter)
-(long_flag_identifier) @variable.parameter
+(short_flag_identifier) @type
+(long_flag_identifier) @type
 
 (scope_pattern [(wild_card) @function])
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10563,6 +10563,19 @@
         }
       ]
     },
+    "flag_value": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_string"
+        }
+      ]
+    },
     "redirection": {
       "type": "CHOICE",
       "members": [
@@ -10727,9 +10740,38 @@
                 "name": "long_flag_identifier"
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "long_flag_equals_value"
           }
         ]
       }
+    },
+    "long_flag_equals_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "--"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "long_flag_identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "long_flag_value"
+        }
+      ]
+    },
+    "long_flag_value": {
+      "type": "SYMBOL",
+      "name": "_cmd_arg"
     },
     "unquoted": {
       "type": "PREC_LEFT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2586,10 +2586,143 @@
       "required": false,
       "types": [
         {
+          "type": "long_flag_equals_value",
+          "named": true
+        },
+        {
           "type": "long_flag_identifier",
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "long_flag_equals_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "long_flag_identifier",
+          "named": true
+        },
+        {
+          "type": "long_flag_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "long_flag_value",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_binary",
+            "named": true
+          },
+          {
+            "type": "val_bool",
+            "named": true
+          },
+          {
+            "type": "val_closure",
+            "named": true
+          },
+          {
+            "type": "val_date",
+            "named": true
+          },
+          {
+            "type": "val_duration",
+            "named": true
+          },
+          {
+            "type": "val_filesize",
+            "named": true
+          },
+          {
+            "type": "val_interpolated",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_nothing",
+            "named": true
+          },
+          {
+            "type": "val_number",
+            "named": true
+          },
+          {
+            "type": "val_range",
+            "named": true
+          },
+          {
+            "type": "val_record",
+            "named": true
+          },
+          {
+            "type": "val_string",
+            "named": true
+          },
+          {
+            "type": "val_table",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
+      "arg_str": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "val_string",
+            "named": true
+          }
+        ]
+      },
+      "flag": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "long_flag",
+            "named": true
+          },
+          {
+            "type": "short_flag",
+            "named": true
+          }
+        ]
+      },
+      "redir": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "redirection",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4709,6 +4842,10 @@
       "types": [
         {
           "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "long_flag_equals_value",
           "named": true
         },
         {

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -468,3 +468,32 @@ cmd-018-pipe-external
           (pipeline
             (pipe_element
               (val_string))))))))
+
+=====
+cmd-019-flags-with-values
+=====
+
+bla --weird-that=this --behaved-differently=than-this --level=2
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+          (long_flag
+            (long_flag_equals_value
+              (long_flag_identifier)
+              (long_flag_value
+                (val_string))))
+          (long_flag
+            (long_flag_equals_value
+              (long_flag_identifier)
+              (long_flag_value
+                (val_string))))
+          (long_flag
+            (long_flag_equals_value
+              (long_flag_identifier)
+              (long_flag_value
+                (val_number))))))))


### PR DESCRIPTION
This PR does three things:
1. highlight `=` in `--long-flag=value` flags (orange in my case)
2. highlight flag identifiers as parameters (blue)
3. highlight string values as strings (green)

Before:
![image](https://github.com/user-attachments/assets/80a7260d-2bd9-4c5d-81b8-9416f84b3667)

After: 
![image](https://github.com/user-attachments/assets/c09237ec-7a3c-4f96-9670-b68897aa7368)


Do we like these changes?