### PR TITLE
fix: flags again

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -220,11 +220,12 @@ key: (identifier) @property
     param_name: (_) @variable.parameter)
 (param_cmd
     (cmd_identifier) @string)
-(param_long_flag (long_flag_identifier) @variable.parameter)
-(param_short_flag (param_short_flag_identifier) @variable.parameter)
 
-(short_flag_identifier) @type
-(long_flag_identifier) @type
+(param_long_flag (long_flag_identifier) @attribute)
+(param_short_flag (param_short_flag_identifier) @attribute)
+
+(short_flag (short_flag_identifier) @attribute)
+(long_flag_identifier) @attribute
 
 (scope_pattern [(wild_card) @function])
 


### PR DESCRIPTION
Last time, I changed identifiers to @type. Most of the time, this is
fine. But when defining a new command with flag parameters, these can
have types and the same highlighting. So now they are attributes and we
have color distinction in both cases.

Before:
![image](https://github.com/user-attachments/assets/74f88844-98a2-42b5-a170-a6b015288ea7)
![image](https://github.com/user-attachments/assets/d1041d4c-f4ab-4f9f-805b-ab8619776dd3)

After:
![image](https://github.com/user-attachments/assets/ead5fa22-ebb6-4e38-83bf-07d2dce26f40)
![image](https://github.com/user-attachments/assets/c98e4f32-5d0a-44b8-bafe-2710e946d0c1)

Since we currently don't have attributes (usually annotations), this is a unique hl-group for flag identifiers.
