### PR TITLE
Fix corner case for ctrl_match with _ and match_guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ path = "bindings/rust/lib.rs"
 # path = "src/main.rs"
 
 [dev-dependencies]
-tree-sitter-language = "0.1.0"
 cc = "1.0"
 
 [dependencies]
+tree-sitter-language = "0.1.0"
 tree-sitter = "~0.20.3"
 
 [build-dependencies]

--- a/grammar.js
+++ b/grammar.js
@@ -428,6 +428,7 @@ module.exports = grammar({
 
     match_pattern: ($) =>
       choice(
+        seq(PUNC().underscore, $.match_guard),
         seq($._match_pattern, optional($.match_guard)),
         seq($._match_pattern, repeat(seq(PUNC().pipe, $._match_pattern))),
       ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3244,6 +3244,19 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "STRING",
+              "value": "_"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "match_guard"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
               "type": "SYMBOL",
               "name": "_match_pattern"
             },

--- a/test/corpus/ctrl/match.nu
+++ b/test/corpus/ctrl/match.nu
@@ -316,3 +316,31 @@ match $x {
                   (identifier)
                   (val_string))))
           (block))))))
+
+=====
+match-009-defaults
+=====
+
+match $x {
+   _ if $x == 4 => {},
+   _ => {}
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_match
+        (val_variable
+          (identifier))
+        (match_arm
+          (match_pattern
+            (match_guard
+              (expr_binary
+                (val_variable
+                  (identifier))
+                (val_number))))
+          (block))
+        (default_arm
+          (block))))))


### PR DESCRIPTION
New test case of "match" with _ and if condition:

```nu
match $x {
   _ if $x == 4 => {},
   _ => {}
}
```

It will previously cause parsing error:

```lisp
(nu_script ; [0, 0] - [4, 0]
  (ERROR ; [0, 0] - [3, 1]
    (val_variable ; [0, 6] - [0, 8]
      name: (identifier)) ; [0, 7] - [0, 8]
    (val_variable ; [1, 7] - [1, 9]
      name: (identifier)) ; [1, 8] - [1, 9]
    (val_number) ; [1, 13] - [1, 14]
    (ERROR) ; [1, 15] - [1, 16]
    (expr_binary ; [1, 18] - [2, 9]
      lhs: (val_record) ; [1, 18] - [1, 20]
      (ERROR) ; [2, 2] - [2, 5]
      rhs: (val_record)))) ; [2, 7] - [2, 9]
```