### PR TITLE
fix: highlights artifact from flags #110

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -74,7 +74,7 @@
 ) @number
 (val_bool) @constant.builtin
 (val_nothing) @constant.builtin
-(val_string) @variable.parameter
+(val_string) @string
 arg_str: (val_string) @variable.parameter
 file_path: (val_string) @variable.parameter
 (val_date) @number


### PR DESCRIPTION
In #110, I changed highlights. I accidentally committed `(val_string) @variable.parameter`, which should actually be `@string`.