### PR TITLE
Allow variables as external command

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1240,6 +1240,7 @@ module.exports = grammar({
         choice(
           field("head", seq(optional(PUNC().caret), $.cmd_identifier)),
           field("head", seq(PUNC().caret, $.val_string)), // Support for ^'command' type of syntax.
+          field("head", seq(PUNC().caret, $.val_variable)), // Support for ^$cmd type of syntax.
           field("head", seq(PUNC().caret, $.expr_parenthesized)), // Support for pipes into external command.
         ),
         prec.dynamic(10, repeat($._cmd_arg)),
@@ -1251,6 +1252,7 @@ module.exports = grammar({
           choice(
             field("head", seq(optional(PUNC().caret), $.cmd_identifier)),
             field("head", seq(PUNC().caret, $.val_string)), // Support for ^'command' type of syntax.
+            field("head", seq(PUNC().caret, $.val_variable)), // Support for ^$cmd type of syntax.
             field("head", seq(PUNC().caret, $.expr_parenthesized)), // Support for pipes into external command.
           ),
           prec.dynamic(10, repeat(seq(optional("\n"), $._cmd_arg))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10365,6 +10365,23 @@
                   },
                   {
                     "type": "SYMBOL",
+                    "name": "val_variable"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "head",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "^"
+                  },
+                  {
+                    "type": "SYMBOL",
                     "name": "expr_parenthesized"
                   }
                 ]
@@ -10432,6 +10449,23 @@
                     {
                       "type": "SYMBOL",
                       "name": "val_string"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "head",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "^"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "val_variable"
                     }
                   ]
                 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -392,6 +392,10 @@
           {
             "type": "val_string",
             "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
           }
         ]
       },

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -497,3 +497,39 @@ bla --weird-that=this --behaved-differently=than-this --level=2
               (long_flag_identifier)
               (long_flag_value
                 (val_number))))))))
+
+======
+cmd-020-variable-external
+======
+
+^$cmd
+
+------
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (val_variable
+          (identifier))))))
+
+======
+cmd-021-variable-external-parenthesized
+======
+
+(^$cmd
+  arg
+)
+
+------
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (command
+              (val_variable
+                (identifier))
+              (val_string))))))))


### PR DESCRIPTION
This PR fixes this kind of parsing error:

<img width="608" alt="image" src="https://github.com/user-attachments/assets/440629a6-daba-4262-ae47-17675ff70b8f">

Added 2 related test cases.