### PR TITLE
Update lazy.nvim installation config

### DIFF
--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -8,14 +8,20 @@ Extend your lazy config with treesitter and the nu parser. The parser doesn't ha
 {
     "nvim-treesitter/nvim-treesitter",
     config = function()
-        -- setup treesitter with config
+        require("nvim-treesitter.configs").setup {
+            ensure_installed = { "nu" }, -- Ensure the "nu" parser is installed
+            highlight = {
+                enable = true,            -- Enable syntax highlighting
+                additional_vim_regex_highlighting = false, -- Set to false if Tree-sitter is used exclusively
+            },
+        }
     end,
     dependencies = {
-        -- NOTE: additional parser
+        -- Additional Nushell parser
         { "nushell/tree-sitter-nu", build = ":TSUpdate nu" },
     },
     build = ":TSUpdate",
-},
+}
 ```
 
 ## Manual installation

--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -12,7 +12,6 @@ Extend your lazy config with treesitter and the nu parser. The parser doesn't ha
             ensure_installed = { "nu" }, -- Ensure the "nu" parser is installed
             highlight = {
                 enable = true,            -- Enable syntax highlighting
-                additional_vim_regex_highlighting = false, -- Set to false if Tree-sitter is used exclusively
             },
         }
     end,

--- a/installation/neovim.md
+++ b/installation/neovim.md
@@ -21,7 +21,7 @@ Extend your lazy config with treesitter and the nu parser. The parser doesn't ha
         { "nushell/tree-sitter-nu", build = ":TSUpdate nu" },
     },
     build = ":TSUpdate",
-}
+},
 ```
 
 ## Manual installation


### PR DESCRIPTION
The current version of the config doesn't enable highlighting of Nushell code.

ChatGPT suggested the changes. I tested the changes with a freshly installed kickstart.nvim and NvChad, and they seem to be working for me. However, I'm a total noob with nvim.