### PR TITLE
fix: fix indent in multiline match expression

### DIFF
--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -1,6 +1,7 @@
 [
   (expr_parenthesized)
   (parameter_bracks)
+  (ctrl_match)
 
   (val_record)
   (val_list)


### PR DESCRIPTION
Fixes a problem where a match expression does not begin an indent.

Before:

![image](https://github.com/user-attachments/assets/9346485b-6501-4c9d-9d4d-c6c8561f7007)

After:

![image](https://github.com/user-attachments/assets/8b44b34e-62f7-4828-b511-52461762b7c6)
