### PR TITLE
Fix unquoted command args with leading +

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1496,8 +1496,9 @@ function _decimal_rule(immediate) {
     choice(
       seq(head_token(/[\d_]*\d[\d_]*/), optional(exponent)),
       seq(
-        choice(head_token(OPR().minus), head_token(OPR().plus)),
-        digits,
+        token(
+          seq(choice(head_token(OPR().minus), head_token(OPR().plus)), digits),
+        ),
         optional(exponent),
       ),
       seq(
@@ -1507,18 +1508,23 @@ function _decimal_rule(immediate) {
         optional(exponent),
       ),
       seq(
-        choice(head_token(OPR().minus), head_token(OPR().plus)),
-        digits,
+        token(
+          seq(choice(head_token(OPR().minus), head_token(OPR().plus)), digits),
+        ),
         token.immediate(PUNC().dot),
         optional(digits),
         optional(exponent),
       ),
       seq(head_token(PUNC().dot), digits, optional(exponent)),
       seq(
-        choice(head_token(OPR().minus), head_token(OPR().plus)),
-        optional(token.immediate(/_+/)),
-        token.immediate(PUNC().dot),
-        digits,
+        token(
+          seq(
+            choice(head_token(OPR().minus), head_token(OPR().plus)),
+            optional(token.immediate(/_+/)),
+            token.immediate(PUNC().dot),
+            digits,
+          ),
+        ),
         optional(exponent),
       ),
     );

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7641,29 +7641,37 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {
@@ -7736,29 +7744,37 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {
@@ -7838,51 +7854,59 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "_+"
-                  }
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "STRING",
-                "value": "."
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "_+"
+                        }
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "STRING",
+                      "value": "."
+                    }
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {
@@ -8100,29 +8124,37 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {
@@ -8195,29 +8227,37 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {
@@ -8297,51 +8337,59 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "_+"
-                  }
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "STRING",
-                "value": "."
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "PATTERN",
-                "value": "[\\d_]*\\d[\\d_]*"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "-"
+                        }
+                      },
+                      {
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "+"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "_+"
+                        }
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "STRING",
+                      "value": "."
+                    }
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[\\d_]*\\d[\\d_]*"
+                    }
+                  }
+                ]
               }
             },
             {

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -904,3 +904,115 @@ echo 1...()
         (val_string
           (expr_parenthesized))))))
 
+======
+cmd-026-unquoted-string-with-leading-plus
+======
+
+echo +100
+echo +_.1
+echo +1.
+echo +1..
+echo +.1..()
+# unquoted below
+chmod +x
+echo +1.f
+echo +.1f
+echo +..1
+echo +
+echo +-
+echo ++1
+echo +.x
+echo +()
+echo +.1()
+echo +..1()
+
+------
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_number))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_number))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_number))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_range
+          (val_number)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_range
+          (val_number)
+          (expr_parenthesized)))))
+  (comment)
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string
+          (expr_parenthesized)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string
+          (expr_parenthesized)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string
+          (expr_parenthesized))))))


### PR DESCRIPTION
This PR fixes #131  by grouping "+/-" and digits in decimals.
Related test cases in `cmd-026-unquoted-string-with-leading-plus`.
