### PR TITLE
Allow unquoted values in val_record

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "nu",
   "word": "identifier",
   "rules": {
@@ -3618,15 +3619,6 @@
           "name": "_match_pattern_value"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expr_unary_minus"
-          },
-          "named": true,
-          "value": "expr_unary"
-        },
-        {
           "type": "SYMBOL",
           "name": "val_range"
         },
@@ -3726,33 +3718,6 @@
                       "content": {
                         "type": "SYMBOL",
                         "name": "_unquoted_in_list"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "short_flag"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "long_flag"
-                      },
-                      "named": true,
-                      "value": "val_string"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_list_item_starts_with_sign"
                       },
                       "named": true,
                       "value": "val_string"
@@ -9518,33 +9483,6 @@
               },
               "named": true,
               "value": "val_string"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "short_flag"
-              },
-              "named": true,
-              "value": "val_string"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "long_flag"
-              },
-              "named": true,
-              "value": "val_string"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_list_item_starts_with_sign"
-              },
-              "named": true,
-              "value": "val_string"
             }
           ]
         }
@@ -9558,52 +9496,12 @@
           "name": "_value"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expr_unary_minus"
-          },
-          "named": true,
-          "value": "expr_unary"
-        },
-        {
           "type": "SYMBOL",
           "name": "val_range"
         },
         {
           "type": "SYMBOL",
           "name": "expr_parenthesized"
-        }
-      ]
-    },
-    "_list_item_starts_with_sign": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "TOKEN",
-              "content": {
-                "type": "STRING",
-                "value": "-"
-              }
-            },
-            {
-              "type": "TOKEN",
-              "content": {
-                "type": "STRING",
-                "value": "+"
-              }
-            }
-          ]
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';]*"
-          }
         }
       ]
     },
@@ -10112,18 +10010,23 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PREC_RIGHT",
-                "value": 10,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "SYMBOL",
+                "name": "_list_item_expression"
               },
               {
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "cmd_identifier"
+                  "name": "_unquoted_in_record"
+                },
+                "named": true,
+                "value": "val_string"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_unquoted_in_record_with_expr"
                 },
                 "named": true,
                 "value": "val_string"
@@ -11223,10 +11126,6 @@
                 }
               },
               {
-                "type": "SYMBOL",
-                "name": "_immediate_decimal"
-              },
-              {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
@@ -11269,7 +11168,7 @@
                 "type": "TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^-$\\s\\n\\t\\r{}()\\[\\]\"`';,][^\\s\\n\\t\\r{}()\\[\\]\"`';,]*"
+                  "value": "[^$\\s\\n\\t\\r{}()\\[\\]\"`';,][^\\s\\n\\t\\r{}()\\[\\]\"`';,]*"
                 }
               }
             }
@@ -11545,10 +11444,6 @@
                 }
               },
               {
-                "type": "SYMBOL",
-                "name": "_immediate_decimal"
-              },
-              {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
@@ -11569,6 +11464,324 @@
                 "content": {
                   "type": "PATTERN",
                   "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';,]+"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_unquoted_in_record": {
+      "type": "PREC_LEFT",
+      "value": -69,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": -69,
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^$\\s\\n\\t\\r{}()\\[\\]\"`';:,][^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_val_range"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,.]"
+                    }
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "STRING",
+                      "value": "."
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "."
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,.]"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ".."
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,=<]"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "..="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "..<"
+                  }
+                ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,$]"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ".."
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "."
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ".."
+              },
+              {
+                "type": "STRING",
+                "value": "..="
+              },
+              {
+                "type": "STRING",
+                "value": "..<"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ".."
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "."
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,.]"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_val_number_decimal"
+                  },
+                  {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                    }
+                  },
+                  {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                    }
+                  },
+                  {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[nN][aA][nN]"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_val_number_decimal"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "."
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_anonymous_prefix"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]+"
                 }
               }
             ]
@@ -11737,6 +11950,89 @@
             "content": {
               "type": "PATTERN",
               "value": "[^\\s\\n\\t\\r();,]*"
+            }
+          }
+        ]
+      }
+    },
+    "_unquoted_in_record_with_expr": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_anonymous_prefix"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_val_number_decimal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_val_range_with_end"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_unquoted_in_record"
+                },
+                "named": false,
+                "value": "_head"
+              }
+            ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expr_parenthesized_immediate"
+            },
+            "named": true,
+            "value": "expr_parenthesized"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "IMMEDIATE_TOKEN",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\n\\t\\r();:,]*"
+                      }
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_expr_parenthesized_immediate"
+                      },
+                      "named": true,
+                      "value": "expr_parenthesized"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "PATTERN",
+              "value": "[^\\s\\n\\t\\r();:,]*"
             }
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2865,10 +2865,6 @@
           "named": true
         },
         {
-          "type": "expr_unary",
-          "named": true
-        },
-        {
           "type": "match_guard",
           "named": true
         },
@@ -2930,6 +2926,7 @@
   {
     "type": "nu_script",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -3755,15 +3752,7 @@
         "required": true,
         "types": [
           {
-            "type": "expr_binary",
-            "named": true
-          },
-          {
             "type": "expr_parenthesized",
-            "named": true
-          },
-          {
-            "type": "expr_unary",
             "named": true
           },
           {
@@ -4439,10 +4428,6 @@
             "named": true
           },
           {
-            "type": "expr_unary",
-            "named": true
-          },
-          {
             "type": "val_binary",
             "named": true
           },
@@ -4580,10 +4565,6 @@
           },
           {
             "type": "expr_parenthesized",
-            "named": true
-          },
-          {
-            "type": "expr_unary",
             "named": true
           },
           {
@@ -4792,18 +4773,6 @@
         },
         {
           "type": "expr_parenthesized",
-          "named": true
-        },
-        {
-          "type": "long_flag_equals_value",
-          "named": true
-        },
-        {
-          "type": "long_flag_identifier",
-          "named": true
-        },
-        {
-          "type": "short_flag_identifier",
           "named": true
         }
       ]

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/test/corpus/expr/list.nu
+++ b/test/corpus/expr/list.nu
@@ -32,8 +32,7 @@ list-001-item-string
           (val_entry
             (val_string))
           (val_entry
-            (val_string
-              (long_flag_identifier))))))))
+            (val_string)))))))
 
 =====
 list-002-unquoted-starts-with-numeric
@@ -398,6 +397,9 @@ list-012-unquoted-vs-range-followed-by-dot
 ======
 
 [
+  .1.
+  1.1.
+  ._1_.
   .1...foo
   1...2.foo
   .1...0.
@@ -416,6 +418,12 @@ list-012-unquoted-vs-range-followed-by-dot
     (pipe_element
       (val_list
         (list_body
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
+          (val_entry
+            (val_string))
           (val_entry
             (val_string))
           (val_entry

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -242,5 +242,231 @@ record-010-key-value-seperation
           (record_entry
             (identifier)
             (ERROR
-              (identifier))
+              (val_string))
             (val_number)))))))
+
+=====
+record-011-immediate-comma
+=====
+
+{
+    export: 556,key: 897
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_number))
+          (record_entry
+            (identifier)
+            (val_number)))))))
+
+=====
+record-012-colon-in-unquoted-value
+=====
+
+{
+  export: "556:error",key: 897
+  export: 556:error,key: 897
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_number))
+          (record_entry
+            (identifier)
+            (ERROR)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_number)))))))
+
+=====
+record-013-value-as-signed-number-or-range
+=====
+
+{k0.0: -_1_.,k0.1: +_1_.1,k0.2: _1._1e-10,
+k1.0: .._1.,k1.1: +_1_._1..=_2.,k1.2: _1_._1..<_2.
+k1.3: -._1..(._1 + 1._1)..=_2.}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_number))
+          (record_entry
+            (identifier)
+            (val_number))
+          (record_entry
+            (identifier)
+            (val_number))
+          (record_entry
+            (identifier)
+            (val_range
+              (val_number)))
+          (record_entry
+            (identifier)
+            (val_range
+              (val_number)
+              (val_number)))
+          (record_entry
+            (identifier)
+            (val_range
+              (val_number)
+              (val_number)))
+          (record_entry
+            (identifier)
+            (val_range
+              (val_number)
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (expr_binary
+                      (val_number)
+                      (val_number)))))
+              (val_number))))))))
+
+=====
+record-014-unquoted-value
+=====
+
+{
+👍: 👍
+k0.0: --long
+k0.1: -short
+k1.0: infms
+k1.1: nankb
+k1.2: true-foo
+k1.3: null-foo
+k2.0: 1ms-foo
+k2.1: 1mb-foo
+k2.2: 2024-01-01foo
+k3.0: .1foo
+k3.1: -__.__.1
+k3.2: .1.
+k3.3: -1.1e-10.
+k4.0: foo(
+  'bar')baz(
+  1)
+k4.1:foo('bar')()
+  k4.2: .()
+k4.3: true()
+k4.4: -()
+k4.5: ..=1()
+k4.6: ..1..<1()
+k4.9: 1...()
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_string))))
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_string))))
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized)))
+          (record_entry
+            (identifier)
+            (val_string
+              (expr_parenthesized))))))))


### PR DESCRIPTION
This PR fixes situations where record value is an unquoted string

<img width="399" alt="image" src="https://github.com/user-attachments/assets/d9d02afb-1179-4273-a6af-0d07b94e8a39">

Also cleaned list_entry rule a little bit since signed numbers, flags and unquoted string start with `+/-` are more easy to distinguish.