### PR TITLE
Fixed some minor errors

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -38,7 +38,7 @@ module.exports = grammar({
 
     nu_script: ($) => seq(optional($.shebang), optional($._block_body)),
 
-    shebang: (_$) => seq("#!", /.*\n/),
+    shebang: (_$) => seq("#!", /.*\r?\n/),
 
     ...block_body_rules("", (/** @type {any} */ $) => $._terminator),
     ...block_body_rules("_last", (/** @type {any} */ $) =>
@@ -88,7 +88,7 @@ module.exports = grammar({
         field("dollar_name", $.val_variable),
       ),
 
-    _terminator: (_$) => choice(PUNC().semicolon, "\n"),
+    _terminator: (_$) => choice(PUNC().semicolon, /\r?\n/),
 
     /// Top Level Items
 
@@ -363,7 +363,7 @@ module.exports = grammar({
           choice($._blosure, $.val_variable),
           repeat(
             seq(
-              choice(token.immediate("\n"), token.immediate(/[ \t]+/)),
+              choice(/\r?\n/, token.immediate(/[ \t]+/)),
               optional($._do_expression),
             ),
           ),
@@ -394,7 +394,7 @@ module.exports = grammar({
           field("then_branch", $.block),
           optional(
             seq(
-              optional("\n"),
+              optional(/\r?\n/),
               KEYWORD().else,
               choice(
                 field("else_block", choice($.block, $._expression, $.command)),
@@ -530,7 +530,7 @@ module.exports = grammar({
           field("try_branch", $.block),
           optional(
             seq(
-              optional("\n"),
+              optional(/\r?\n/),
               KEYWORD().catch,
               field("catch_branch", $._blosure),
             ),
@@ -567,8 +567,8 @@ module.exports = grammar({
           $.command,
         ),
         // Allow for empty pipeline elements like `ls | | print`
-        repeat1(seq(optional("\n"), PUNC().pipe)),
-        optional("\n"),
+        repeat1(seq(optional(/\r?\n/), PUNC().pipe)),
+        optional(/\r?\n/),
       ),
 
     pipe_element_parenthesized: ($) =>
@@ -580,8 +580,8 @@ module.exports = grammar({
           alias($._command_parenthesized_body, $.command),
         ),
         // Allow for empty pipeline elements like `ls | | print`
-        repeat1(seq(optional("\n"), PUNC().pipe)),
-        optional("\n"),
+        repeat1(seq(optional(/\r?\n/), PUNC().pipe)),
+        optional(/\r?\n/),
       ),
 
     pipe_element_last: ($) =>
@@ -1075,8 +1075,7 @@ module.exports = grammar({
       "_entry_separator",
     ),
 
-    _entry_separator: (_$) =>
-      token(prec(20, choice(PUNC().comma, /\s/, /[\r\n]/))),
+    _entry_separator: (_$) => token(prec(20, choice(PUNC().comma, /\s/))),
 
     record_entry: ($) =>
       seq(
@@ -1187,7 +1186,7 @@ module.exports = grammar({
             10,
             repeat(
               seq(
-                choice(token.immediate("\n"), token.immediate(/[ \t]+/)),
+                choice(/\r?\n/, token.immediate(/[ \t]+/)),
                 optional($._cmd_arg),
               ),
             ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2803,8 +2803,13 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "ctrl_do"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ctrl_do_parenthesized"
+          },
+          "named": true,
+          "value": "ctrl_do"
         },
         {
           "type": "ALIAS",
@@ -2994,6 +2999,37 @@
         }
       ]
     },
+    "_do_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_list_item_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_flag"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "unquoted"
+          },
+          "named": true,
+          "value": "val_string"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_unquoted_with_expr"
+          },
+          "named": true,
+          "value": "val_string"
+        }
+      ]
+    },
     "ctrl_do": {
       "type": "PREC_LEFT",
       "value": -1,
@@ -3005,52 +3041,11 @@
             "value": "do"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flag"
+            }
           },
           {
             "type": "CHOICE",
@@ -3066,112 +3061,103 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[ \\t]+"
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_do_expression"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ctrl_do_parenthesized": {
+      "type": "PREC_LEFT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "do"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flag"
+            }
           },
           {
             "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_flag"
+                "name": "_blosure"
               },
               {
-                "type": "BLANK"
+                "type": "SYMBOL",
+                "name": "val_variable"
               }
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_flag"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "IMMEDIATE_TOKEN",
+                      "content": {
+                        "type": "STRING",
+                        "value": "\n"
+                      }
+                    },
+                    {
+                      "type": "IMMEDIATE_TOKEN",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[ \\t]+"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_do_expression"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
           }
         ]
       }
@@ -4353,6 +4339,13 @@
         {
           "type": "STRING",
           "value": "hide-env"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_flag"
+          }
         },
         {
           "type": "FIELD",
@@ -9354,7 +9347,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block_body"
+          "name": "_parenthesized_body"
         },
         {
           "type": "STRING",
@@ -10535,18 +10528,6 @@
                 ]
               }
             }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "\n"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -41,7 +41,7 @@
         },
         {
           "type": "PATTERN",
-          "value": ".*\\n"
+          "value": ".*\\r?\\n"
         }
       ]
     },
@@ -1644,8 +1644,8 @@
           "value": ";"
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\r?\\n"
         }
       ]
     },
@@ -3129,11 +3129,8 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "IMMEDIATE_TOKEN",
-                      "content": {
-                        "type": "STRING",
-                        "value": "\n"
-                      }
+                      "type": "PATTERN",
+                      "value": "\\r?\\n"
                     },
                     {
                       "type": "IMMEDIATE_TOKEN",
@@ -3292,8 +3289,8 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\n"
+                        "type": "PATTERN",
+                        "value": "\\r?\\n"
                       },
                       {
                         "type": "BLANK"
@@ -3923,8 +3920,8 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\n"
+                        "type": "PATTERN",
+                        "value": "\\r?\\n"
                       },
                       {
                         "type": "BLANK"
@@ -4037,8 +4034,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "\n"
+                    "type": "PATTERN",
+                    "value": "\\r?\\n"
                   },
                   {
                     "type": "BLANK"
@@ -4056,8 +4053,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "\n"
+              "type": "PATTERN",
+              "value": "\\r?\\n"
             },
             {
               "type": "BLANK"
@@ -4108,8 +4105,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "\n"
+                    "type": "PATTERN",
+                    "value": "\\r?\\n"
                   },
                   {
                     "type": "BLANK"
@@ -4127,8 +4124,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "\n"
+              "type": "PATTERN",
+              "value": "\\r?\\n"
             },
             {
               "type": "BLANK"
@@ -9604,10 +9601,6 @@
             {
               "type": "PATTERN",
               "value": "\\s"
-            },
-            {
-              "type": "PATTERN",
-              "value": "[\\r\\n]"
             }
           ]
         }
@@ -10498,11 +10491,8 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "IMMEDIATE_TOKEN",
-                        "content": {
-                          "type": "STRING",
-                          "value": "\n"
-                        }
+                        "type": "PATTERN",
+                        "value": "\\r?\\n"
                       },
                       {
                         "type": "IMMEDIATE_TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5298,10 +5298,6 @@
     "fields": {}
   },
   {
-    "type": "\n",
-    "named": false
-  },
-  {
     "type": "!=",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -411,15 +411,7 @@
           "named": true
         },
         {
-          "type": "expr_binary",
-          "named": true
-        },
-        {
           "type": "expr_parenthesized",
-          "named": true
-        },
-        {
-          "type": "expr_unary",
           "named": true
         },
         {
@@ -2398,6 +2390,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "long_flag",
+          "named": true
+        },
+        {
+          "type": "short_flag",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/test/corpus/ctrl/do.nu
+++ b/test/corpus/ctrl/do.nu
@@ -1,0 +1,158 @@
+=====
+do-001-smoke-test
+=====
+
+do {echo hello}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (block
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_string)))))))))
+
+=====
+do-002-flags
+=====
+
+do -c --env { thisisnotarealcommand } # flags before block
+do -c { thisisnotarealcommand } --env # flags on both sides
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (short_flag
+          (short_flag_identifier))
+        (long_flag
+          (long_flag_identifier))
+        (block
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)))))))
+    (comment))
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (short_flag
+          (short_flag_identifier))
+        (block
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)))))
+        (long_flag
+          (long_flag_identifier))))
+    (comment)))
+
+=====
+do-003-parameters
+=====
+
+do {|x,y| $x} 77 100 # 2 positional parameters
+do {|x,y| $x} 77, -c unquoted # flags in-between
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier))
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (val_variable
+                (identifier)))))
+        (val_number)
+        (val_number)))
+    (comment))
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (val_closure
+          (parameter_pipes
+            (parameter
+              (identifier))
+            (parameter
+              (identifier)))
+          (pipeline
+            (pipe_element
+              (val_variable
+                (identifier)))))
+        (val_string)
+        (short_flag
+          (short_flag_identifier))
+        (val_string)))
+    (comment)))
+
+=====
+do-004-parenthesized
+=====
+
+$'(do {|x,y| $x} 77, # string
+...2 # range
+-c # flag
+(1 + 1) foo('bar')
+unquoted; # string
+another_pipeline
+)'
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_interpolated
+        (expr_interpolated
+          (pipeline
+            (pipe_element
+              (ctrl_do
+                (val_closure
+                  (parameter_pipes
+                    (parameter
+                      (identifier))
+                    (parameter
+                      (identifier)))
+                  (pipeline
+                    (pipe_element
+                      (val_variable
+                        (identifier)))))
+                (val_string)
+                (comment)
+                (val_range
+                  (val_number))
+                (comment)
+                (short_flag
+                  (short_flag_identifier))
+                (comment)
+                (expr_parenthesized
+                  (pipeline
+                    (pipe_element
+                      (expr_binary
+                        (val_number)
+                        (val_number)))))
+                (val_string
+                  (expr_parenthesized
+                    (pipeline
+                      (pipe_element
+                        (val_string)))))
+                (val_string))))
+          (comment)
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)))))))))

--- a/test/corpus/expr/values.nu
+++ b/test/corpus/expr/values.nu
@@ -207,3 +207,70 @@ values-006-not-a-number
             (val_number))
           (val_entry
             (val_number)))))))
+
+=====
+values-007-interpolated-string
+=====
+
+$"foo(1)bar"
+$'foo(1)bar'
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_interpolated
+        (escaped_interpolated_content)
+        (expr_interpolated
+          (pipeline
+            (pipe_element
+              (val_number))))
+        (escaped_interpolated_content))))
+  (pipeline
+    (pipe_element
+      (val_interpolated
+        (unescaped_interpolated_content)
+        (expr_interpolated
+          (pipeline
+            (pipe_element
+              (val_number))))
+        (unescaped_interpolated_content)))))
+
+=====
+values-008-interpolated-string-multiline-command
+=====
+
+$'foo(
+  echo foo # should be single pipeline
+  $'( # comment
+    echo nested
+    val_interpolated # should be command argument
+  )'
+)bar'
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_interpolated
+        (unescaped_interpolated_content)
+        (expr_interpolated
+          (pipeline
+            (pipe_element
+              (command
+                (cmd_identifier)
+                (val_string)
+                (comment)
+                (val_interpolated
+                  (expr_interpolated
+                    (comment)
+                    (pipeline
+                      (pipe_element
+                        (command
+                          (cmd_identifier)
+                          (val_string)
+                          (val_string)
+                          (comment))))))))))
+        (unescaped_interpolated_content)))))

--- a/test/corpus/stmt/hide.nu
+++ b/test/corpus/stmt/hide.nu
@@ -45,3 +45,22 @@ hide-env FOO;
 (nu_script
   (hide_env
     (identifier)))
+
+=====
+hide-env-003-flag
+=====
+
+hide-env -i FOO;
+hide-env --ignore-errors FOO;
+
+-----
+
+(nu_script
+  (hide_env
+    (short_flag
+      (short_flag_identifier))
+    (identifier))
+  (hide_env
+    (long_flag
+      (long_flag_identifier))
+    (identifier)))


### PR DESCRIPTION
This PR fixed following issues in current grammar:
1. hide-env with flags

<img width="555" alt="image" src="https://github.com/user-attachments/assets/f781c461-e753-4f32-9465-fe0c81a1817a">

2. do + closure + more than one arguments / parenthesized multiline do statement

<img width="599" alt="image" src="https://github.com/user-attachments/assets/4b9be6c1-8bf2-42b7-b512-89dff78099d1">

3. wrong result for multiline `expr_interpolated` (here `bar` should be argument instead of the command head of another pipeline)

<img width="599" alt="image" src="https://github.com/user-attachments/assets/f16ddabe-ff87-4410-b728-c5081daf00bf">

4. hide those `"\n"` terminal tokens, which makes it easier for query, also more windows friendly.