### PR TITLE
Fix spread operators & redirections

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -146,10 +146,7 @@ module.exports = grammar({
         seq(
           optional(MODIFIER().visibility),
           KEYWORD().use,
-          field(
-            "module",
-            choice(alias($.unquoted, $.val_string), $._stringish),
-          ),
+          field("module", choice($.unquoted, $._stringish)),
           optional(field("import_pattern", $.scope_pattern)),
         ),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -7,6 +7,17 @@ module.exports = grammar({
 
   extras: ($) => [/[ \t]/, $.comment],
 
+  inline: ($) => [
+    $._do_expression,
+    $._item_expression,
+    $._match_expression,
+    $._separator,
+    $._spread_listish,
+    $._spread_recordish,
+    $._stringish,
+    $._terminator,
+  ],
+
   // externals: $ => [
   //   $.long_flag_equals_value
   // ],
@@ -16,17 +27,14 @@ module.exports = grammar({
     [$._expression, $._expr_binary_expression],
     [$._expression_parenthesized, $._expr_binary_expression_parenthesized],
     [$._immediate_decimal],
-    [$._match_pattern_expression, $._item_expression],
     [$._match_pattern_list, $.val_list],
     [$._match_pattern_record, $.val_record],
     [$._match_pattern_record_variable, $._value],
     [$._match_pattern_value, $._value],
     [$._parenthesized_body],
-    [$._terminator, $._parenthesized_body],
-    [$._terminator, $.parameter_pipes, $.record_body],
-    [$._terminator, $.parameter_pipes],
-    [$._terminator, $.shebang],
-    [$._terminator],
+    [$._block_body, $.parameter_pipes, $.record_body],
+    [$._block_body, $.parameter_pipes],
+    [$._block_body, $.shebang],
     [$._val_number_decimal],
     [$.block, $.val_closure],
     [$.block, $.val_record],

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -204,6 +204,9 @@ file_path: (val_string) @variable.parameter
     "(" ")"
     "{" "}"
     "[" "]"
+    "...["
+    "...("
+    "...{"
 ] @punctuation.bracket
 
 (val_record
@@ -274,7 +277,8 @@ key: (identifier) @property
 (stmt_let (identifier) @variable)
 
 (val_variable
-  "$" @punctuation.special
+  "$"? @punctuation.special
+  "...$"? @punctuation.special
   [
    (identifier) @variable
    "in" @special

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -12586,10 +12586,6 @@
       "_immediate_decimal"
     ],
     [
-      "_match_pattern_expression",
-      "_item_expression"
-    ],
-    [
       "_match_pattern_list",
       "val_list"
     ],
@@ -12609,24 +12605,17 @@
       "_parenthesized_body"
     ],
     [
-      "_terminator",
-      "_parenthesized_body"
-    ],
-    [
-      "_terminator",
+      "_block_body",
       "parameter_pipes",
       "record_body"
     ],
     [
-      "_terminator",
+      "_block_body",
       "parameter_pipes"
     ],
     [
-      "_terminator",
+      "_block_body",
       "shebang"
-    ],
-    [
-      "_terminator"
     ],
     [
       "_val_number_decimal"
@@ -12657,6 +12646,15 @@
   ],
   "precedences": [],
   "externals": [],
-  "inline": [],
+  "inline": [
+    "_do_expression",
+    "_item_expression",
+    "_match_expression",
+    "_separator",
+    "_spread_listish",
+    "_spread_recordish",
+    "_stringish",
+    "_terminator"
+  ],
   "supertypes": []
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1227,13 +1227,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "unquoted"
-                  },
-                  "named": true,
-                  "value": "val_string"
+                  "type": "SYMBOL",
+                  "name": "unquoted"
                 },
                 {
                   "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -950,11 +950,45 @@
             }
           },
           {
-            "type": "TOKEN",
-            "content": {
-              "type": "STRING",
-              "value": "|"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "|"
+              },
+              {
+                "type": "STRING",
+                "value": "err>|"
+              },
+              {
+                "type": "STRING",
+                "value": "out>|"
+              },
+              {
+                "type": "STRING",
+                "value": "e>|"
+              },
+              {
+                "type": "STRING",
+                "value": "o>|"
+              },
+              {
+                "type": "STRING",
+                "value": "err+out>|"
+              },
+              {
+                "type": "STRING",
+                "value": "out+err>|"
+              },
+              {
+                "type": "STRING",
+                "value": "o+e>|"
+              },
+              {
+                "type": "STRING",
+                "value": "e+o>|"
+              }
+            ]
           }
         ]
       }
@@ -1193,20 +1227,17 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "val_string"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "unquoted"
+                  },
+                  "named": true,
+                  "value": "val_string"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "val_interpolated"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "expr_parenthesized"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unquoted"
+                  "name": "_stringish"
                 }
               ]
             }
@@ -2368,7 +2399,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_list_item_expression"
+          "name": "_item_expression"
         },
         {
           "type": "SYMBOL",
@@ -3400,8 +3431,25 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "redirection"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -3421,8 +3469,25 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression_parenthesized"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression_parenthesized"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "redirection"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -3481,19 +3546,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "val_string"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "expr_parenthesized"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "val_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "val_interpolated"
+                "name": "_stringish"
               }
             ]
           }
@@ -7037,6 +7090,43 @@
         }
       ]
     },
+    "_spread_parenthesized": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "...("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_parenthesized_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "cell_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "_expr_parenthesized_immediate": {
       "type": "SEQ",
       "members": [
@@ -8272,29 +8362,36 @@
         }
       ]
     },
-    "val_variable": {
-      "type": "CHOICE",
+    "_spread_variable": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_var"
+          "type": "STRING",
+          "value": "...$"
         },
         {
-          "type": "SEQ",
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_var"
+              "name": "cell_path"
             },
             {
-              "type": "SYMBOL",
-              "name": "cell_path"
+              "type": "BLANK"
             }
           ]
         }
       ]
     },
-    "_var": {
+    "val_variable": {
       "type": "SEQ",
       "members": [
         {
@@ -8325,6 +8422,18 @@
               }
             ]
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "cell_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -9156,6 +9265,27 @@
         ]
       }
     },
+    "_stringish": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "val_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_interpolated"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expr_parenthesized"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_variable"
+        }
+      ]
+    },
     "val_string": {
       "type": "CHOICE",
       "members": [
@@ -9456,6 +9586,75 @@
         }
       ]
     },
+    "_spread_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "...["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "list_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "cell_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_spread_listish": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_list"
+          },
+          "named": true,
+          "value": "val_list"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_variable"
+          },
+          "named": true,
+          "value": "val_variable"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_parenthesized"
+          },
+          "named": true,
+          "value": "expr_parenthesized"
+        }
+      ]
+    },
     "list_body": {
       "type": "PREC",
       "value": 20,
@@ -9526,7 +9725,15 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_list_item_expression"
+              "name": "_item_expression"
+            },
+            {
+              "type": "FIELD",
+              "name": "spread",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_spread_listish"
+              }
             },
             {
               "type": "ALIAS",
@@ -9550,7 +9757,7 @@
         }
       }
     },
-    "_list_item_expression": {
+    "_item_expression": {
       "type": "CHOICE",
       "members": [
         {
@@ -9601,6 +9808,75 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "_spread_record": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "...{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "record_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "cell_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_spread_recordish": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_record"
+          },
+          "named": true,
+          "value": "val_record"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_variable"
+          },
+          "named": true,
+          "value": "val_variable"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_parenthesized"
+          },
+          "named": true,
+          "value": "expr_parenthesized"
         }
       ]
     },
@@ -9684,439 +9960,452 @@
       }
     },
     "record_entry": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
           "type": "FIELD",
-          "name": "key",
+          "name": "spread",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "cmd_identifier"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "val_string"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "val_number"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "val_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "expr_parenthesized"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_record_key"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "def"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "alias"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "use"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "export-env"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "extern"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "module"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "let"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "let-env"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "mut"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "const"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "hide"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "hide-env"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "source"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "source-env"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "overlay"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "register"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "for"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "loop"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "while"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "error"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "do"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "if"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "else"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "try"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "catch"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "match"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "break"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "return"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "as"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "in"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "hide"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "list"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "new"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "use"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "make"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "export"
-                },
-                "named": true,
-                "value": "identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_spread_recordish"
           }
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "TOKEN",
-            "content": {
-              "type": "PREC",
-              "value": 20,
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "key",
               "content": {
-                "type": "SEQ",
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "\\s*"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "cmd_identifier"
+                    },
+                    "named": true,
+                    "value": "identifier"
                   },
                   {
-                    "type": "STRING",
-                    "value": ":"
+                    "type": "SYMBOL",
+                    "name": "val_string"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "val_number"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "val_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "expr_parenthesized"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_record_key"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "def"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "alias"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "use"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "export-env"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "extern"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "module"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "let"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "let-env"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "mut"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "const"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "hide"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "hide-env"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "source"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "source-env"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "overlay"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "register"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "for"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "loop"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "while"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "error"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "if"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "else"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "try"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "catch"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "match"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "break"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "continue"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "return"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "as"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "in"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "hide"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "list"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "new"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "use"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "make"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "export"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 20,
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\\s*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ":"
+                      }
+                    ]
+                  }
+                }
+              },
+              "named": false,
+              "value": ":"
+            },
+            {
+              "type": "FIELD",
+              "name": "value",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_item_expression"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_in_record"
+                    },
+                    "named": true,
+                    "value": "val_string"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_in_record_with_expr"
+                    },
+                    "named": true,
+                    "value": "val_string"
                   }
                 ]
               }
             }
-          },
-          "named": false,
-          "value": ":"
-        },
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_list_item_expression"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_unquoted_in_record"
-                },
-                "named": true,
-                "value": "val_string"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_unquoted_in_record_with_expr"
-                },
-                "named": true,
-                "value": "val_string"
-              }
-            ]
-          }
+          ]
         }
       ]
     },
@@ -10344,20 +10633,11 @@
       "type": "PREC_RIGHT",
       "value": 1,
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "path"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "path"
-            }
-          }
-        ]
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "path"
+        }
       }
     },
     "path": {
@@ -10380,32 +10660,24 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "PREC_RIGHT",
-                    "value": 2,
+                    "type": "TOKEN",
                     "content": {
-                      "type": "TOKEN",
+                      "type": "PREC",
+                      "value": -1,
                       "content": {
                         "type": "PATTERN",
-                        "value": "[0-9a-zA-Z_-]+"
+                        "value": "[^\\s\\n\\t\\r\\|(){}\\[\\].,:;?]+"
                       }
                     }
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_str_double_quotes"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_str_single_quotes"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_str_back_ticks"
-                      }
-                    ]
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "val_string"
+                    },
+                    "named": false,
+                    "value": "quoted"
                   }
                 ]
               }
@@ -10420,32 +10692,24 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "PREC_RIGHT",
-                        "value": 2,
+                        "type": "TOKEN",
                         "content": {
-                          "type": "TOKEN",
+                          "type": "PREC",
+                          "value": -1,
                           "content": {
                             "type": "PATTERN",
-                            "value": "[0-9a-zA-Z_-]+"
+                            "value": "[^\\s\\n\\t\\r\\|(){}\\[\\].,:;?]+"
                           }
                         }
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_str_double_quotes"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_str_single_quotes"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_str_back_ticks"
-                          }
-                        ]
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "val_string"
+                        },
+                        "named": false,
+                        "value": "quoted"
                       }
                     ]
                   },
@@ -10503,41 +10767,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "val_string"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "head",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "^"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "val_variable"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "head",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "^"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "expr_parenthesized"
+                    "name": "_stringish"
                   }
                 ]
               }
@@ -10620,41 +10850,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "val_string"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "head",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "^"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "val_variable"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "head",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "^"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "expr_parenthesized"
+                      "name": "_stringish"
                     }
                   ]
                 }
@@ -10757,6 +10953,14 @@
         },
         {
           "type": "FIELD",
+          "name": "arg_spread",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_spread_listish"
+          }
+        },
+        {
+          "type": "FIELD",
           "name": "arg_str",
           "content": {
             "type": "ALIAS",
@@ -10797,89 +11001,109 @@
       ]
     },
     "redirection": {
-      "type": "PREC_RIGHT",
-      "value": 10,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "err>"
-              },
-              {
-                "type": "STRING",
-                "value": "out>"
-              },
-              {
-                "type": "STRING",
-                "value": "e>"
-              },
-              {
-                "type": "STRING",
-                "value": "o>"
-              },
-              {
-                "type": "STRING",
-                "value": "err+out>"
-              },
-              {
-                "type": "STRING",
-                "value": "out+err>"
-              },
-              {
-                "type": "STRING",
-                "value": "o+e>"
-              },
-              {
-                "type": "STRING",
-                "value": "e+o>"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "err>"
+            },
+            {
+              "type": "STRING",
+              "value": "out>"
+            },
+            {
+              "type": "STRING",
+              "value": "e>"
+            },
+            {
+              "type": "STRING",
+              "value": "o>"
+            },
+            {
+              "type": "STRING",
+              "value": "err+out>"
+            },
+            {
+              "type": "STRING",
+              "value": "out+err>"
+            },
+            {
+              "type": "STRING",
+              "value": "o+e>"
+            },
+            {
+              "type": "STRING",
+              "value": "e+o>"
+            },
+            {
+              "type": "STRING",
+              "value": "err>>"
+            },
+            {
+              "type": "STRING",
+              "value": "out>>"
+            },
+            {
+              "type": "STRING",
+              "value": "e>>"
+            },
+            {
+              "type": "STRING",
+              "value": "o>>"
+            },
+            {
+              "type": "STRING",
+              "value": "err+out>>"
+            },
+            {
+              "type": "STRING",
+              "value": "out+err>>"
+            },
+            {
+              "type": "STRING",
+              "value": "o+e>>"
+            },
+            {
+              "type": "STRING",
+              "value": "e+o>>"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_space"
+            },
+            {
+              "type": "FIELD",
+              "name": "file_path",
+              "content": {
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_space"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_naive"
+                    },
+                    "named": true,
+                    "value": "val_string"
                   },
                   {
-                    "type": "FIELD",
-                    "name": "file_path",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "unquoted"
-                          },
-                          "named": true,
-                          "value": "val_string"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_expression"
-                        }
-                      ]
-                    }
+                    "type": "SYMBOL",
+                    "name": "_stringish"
                   }
                 ]
-              },
-              {
-                "type": "BLANK"
               }
-            ]
-          }
-        ]
-      }
+            }
+          ]
+        }
+      ]
     },
     "_flag": {
       "type": "PREC_RIGHT",
@@ -10988,6 +11212,13 @@
     "long_flag_value": {
       "type": "SYMBOL",
       "name": "_cmd_arg"
+    },
+    "_unquoted_naive": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[^\\s\\n\\t\\r(){}\\|;]+"
+      }
     },
     "unquoted": {
       "type": "PREC_LEFT",
@@ -12229,6 +12460,38 @@
         },
         {
           "type": "STRING",
+          "value": "err>>"
+        },
+        {
+          "type": "STRING",
+          "value": "out>>"
+        },
+        {
+          "type": "STRING",
+          "value": "e>>"
+        },
+        {
+          "type": "STRING",
+          "value": "o>>"
+        },
+        {
+          "type": "STRING",
+          "value": "err+out>>"
+        },
+        {
+          "type": "STRING",
+          "value": "out+err>>"
+        },
+        {
+          "type": "STRING",
+          "value": "o+e>>"
+        },
+        {
+          "type": "STRING",
+          "value": "e+o>>"
+        },
+        {
+          "type": "STRING",
           "value": "null"
         },
         {
@@ -12324,7 +12587,7 @@
     ],
     [
       "_match_pattern_expression",
-      "_list_item_expression"
+      "_item_expression"
     ],
     [
       "_match_pattern_list",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1497,6 +1497,10 @@
             "named": true
           },
           {
+            "type": "unquoted",
+            "named": true
+          },
+          {
             "type": "val_interpolated",
             "named": true
           },
@@ -4263,6 +4267,11 @@
         ]
       }
     }
+  },
+  {
+    "type": "unquoted",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "val_binary",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -291,6 +291,24 @@
           }
         ]
       },
+      "arg_spread": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
       "arg_str": {
         "multiple": true,
         "required": false,
@@ -329,6 +347,10 @@
           },
           {
             "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_interpolated",
             "named": true
           },
           {
@@ -1475,15 +1497,15 @@
             "named": true
           },
           {
-            "type": "unquoted",
-            "named": true
-          },
-          {
             "type": "val_interpolated",
             "named": true
           },
           {
             "type": "val_string",
+            "named": true
+          },
+          {
+            "type": "val_variable",
             "named": true
           }
         ]
@@ -2641,6 +2663,24 @@
           }
         ]
       },
+      "arg_spread": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
       "arg_str": {
         "multiple": false,
         "required": false,
@@ -3531,30 +3571,22 @@
         "required": false,
         "types": [
           {
-            "type": "\"",
-            "named": false
-          },
-          {
             "type": "?",
             "named": false
           },
           {
-            "type": "escape_sequence",
-            "named": true
+            "type": "quoted",
+            "named": false
           }
         ]
       },
       "raw_path": {
-        "multiple": true,
+        "multiple": false,
         "required": false,
         "types": [
           {
-            "type": "\"",
+            "type": "quoted",
             "named": false
-          },
-          {
-            "type": "escape_sequence",
-            "named": true
           }
         ]
       }
@@ -3586,7 +3618,7 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -3623,6 +3655,10 @@
         },
         {
           "type": "expr_unary",
+          "named": true
+        },
+        {
+          "type": "redirection",
           "named": true
         },
         {
@@ -3708,6 +3744,21 @@
     }
   },
   {
+    "type": "quoted",
+    "named": false,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "record_body",
     "named": true,
     "fields": {
@@ -3729,7 +3780,7 @@
     "fields": {
       "key": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "expr_parenthesized",
@@ -3753,9 +3804,27 @@
           }
         ]
       },
+      "spread": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_record",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
       "value": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "expr_parenthesized",
@@ -3831,42 +3900,10 @@
     "fields": {
       "file_path": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
-            "type": "expr_binary",
-            "named": true
-          },
-          {
             "type": "expr_parenthesized",
-            "named": true
-          },
-          {
-            "type": "expr_unary",
-            "named": true
-          },
-          {
-            "type": "val_binary",
-            "named": true
-          },
-          {
-            "type": "val_bool",
-            "named": true
-          },
-          {
-            "type": "val_closure",
-            "named": true
-          },
-          {
-            "type": "val_date",
-            "named": true
-          },
-          {
-            "type": "val_duration",
-            "named": true
-          },
-          {
-            "type": "val_filesize",
             "named": true
           },
           {
@@ -3874,31 +3911,7 @@
             "named": true
           },
           {
-            "type": "val_list",
-            "named": true
-          },
-          {
-            "type": "val_nothing",
-            "named": true
-          },
-          {
-            "type": "val_number",
-            "named": true
-          },
-          {
-            "type": "val_range",
-            "named": true
-          },
-          {
-            "type": "val_record",
-            "named": true
-          },
-          {
             "type": "val_string",
-            "named": true
-          },
-          {
-            "type": "val_table",
             "named": true
           },
           {
@@ -4252,11 +4265,6 @@
     }
   },
   {
-    "type": "unquoted",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "val_binary",
     "named": true,
     "fields": {
@@ -4427,7 +4435,7 @@
     "fields": {
       "item": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "expr_parenthesized",
@@ -4487,6 +4495,24 @@
           },
           {
             "type": "val_table",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
+      "spread": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_list",
             "named": true
           },
           {
@@ -5470,6 +5496,22 @@
     "named": false
   },
   {
+    "type": "...$",
+    "named": false
+  },
+  {
+    "type": "...(",
+    "named": false
+  },
+  {
+    "type": "...[",
+    "named": false
+  },
+  {
+    "type": "...{",
+    "named": false
+  },
+  {
     "type": "..<",
     "named": false
   },
@@ -5686,7 +5728,23 @@
     "named": false
   },
   {
+    "type": "e+o>>",
+    "named": false
+  },
+  {
+    "type": "e+o>|",
+    "named": false
+  },
+  {
     "type": "e>",
+    "named": false
+  },
+  {
+    "type": "e>>",
+    "named": false
+  },
+  {
+    "type": "e>|",
     "named": false
   },
   {
@@ -5706,7 +5764,23 @@
     "named": false
   },
   {
+    "type": "err+out>>",
+    "named": false
+  },
+  {
+    "type": "err+out>|",
+    "named": false
+  },
+  {
     "type": "err>",
+    "named": false
+  },
+  {
+    "type": "err>>",
+    "named": false
+  },
+  {
+    "type": "err>|",
     "named": false
   },
   {
@@ -5878,7 +5952,23 @@
     "named": false
   },
   {
+    "type": "o+e>>",
+    "named": false
+  },
+  {
+    "type": "o+e>|",
+    "named": false
+  },
+  {
     "type": "o>",
+    "named": false
+  },
+  {
+    "type": "o>>",
+    "named": false
+  },
+  {
+    "type": "o>|",
     "named": false
   },
   {
@@ -5898,7 +5988,23 @@
     "named": false
   },
   {
+    "type": "out+err>>",
+    "named": false
+  },
+  {
+    "type": "out+err>|",
+    "named": false
+  },
+  {
     "type": "out>",
+    "named": false
+  },
+  {
+    "type": "out>>",
+    "named": false
+  },
+  {
+    "type": "out>|",
     "named": false
   },
   {

--- a/test/corpus/decl/use.nu
+++ b/test/corpus/decl/use.nu
@@ -8,7 +8,7 @@ use file.nu
 
 (nu_script
   (decl_use
-    (val_string)))
+    (unquoted)))
 
 =====
 use-002-semicolon
@@ -20,7 +20,7 @@ use dir/file.nu;
 
 (nu_script
   (decl_use
-    (val_string)))
+    (unquoted)))
 
 =====
 use-003-pipe
@@ -71,7 +71,7 @@ use foo.nu [
 
 (nu_script
   (decl_use
-    (val_string)
+    (unquoted)
     (scope_pattern
       (command_list
         (cmd_identifier)

--- a/test/corpus/decl/use.nu
+++ b/test/corpus/decl/use.nu
@@ -8,7 +8,7 @@ use file.nu
 
 (nu_script
   (decl_use
-    (unquoted)))
+    (val_string)))
 
 =====
 use-002-semicolon
@@ -20,7 +20,7 @@ use dir/file.nu;
 
 (nu_script
   (decl_use
-    (unquoted)))
+    (val_string)))
 
 =====
 use-003-pipe
@@ -71,7 +71,7 @@ use foo.nu [
 
 (nu_script
   (decl_use
-    (unquoted)
+    (val_string)
     (scope_pattern
       (command_list
         (cmd_identifier)

--- a/test/corpus/expr/cell_path.nu
+++ b/test/corpus/expr/cell_path.nu
@@ -18,24 +18,24 @@ let x = $list.4
 
 ======
 cellpath-002-str-access
-=====
+======
 
 let x = $env.PATH
 
 -----
 
-    (nu_script
-      (stmt_let
-        (identifier)
-        (pipeline
-          (pipe_element
-            (val_variable
-              (cell_path
-                (path)))))))
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_variable
+          (cell_path
+            (path)))))))
 
 ====
 cellpath-003-multiple-access
-=====
+====
 
 let x = $list.PATH.4
 
@@ -54,7 +54,7 @@ let x = $list.PATH.4
 
 ====
 cellpath-004-underscore-in-path
-=====
+====
 
 let x = $env.LAST_EXIT_CODE
 
@@ -71,7 +71,7 @@ let x = $env.LAST_EXIT_CODE
 
 ====
 cellpath-005-hyphen-in-path
-=====
+====
 
 let x = $nu.home-path
 
@@ -85,3 +85,75 @@ let x = $nu.home-path
         (val_variable
           (cell_path
             (path)))))))
+
+====
+cellpath-006-immediate-punctuation
+====
+
+($env.PATH)
+[$env.PATH]
+{$env.PATH}
+{$env.PATH: 1}
+[$env.PATH,]
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (val_variable
+              (cell_path
+                (path))))))))
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          (val_entry
+            (val_variable
+              (cell_path
+                (path))))))))
+  (pipeline
+    (pipe_element
+      (val_closure
+        (pipeline
+          (pipe_element
+            (val_variable
+              (cell_path
+                (path))))))))
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (val_variable
+              (cell_path
+                (path)))
+            (val_number))))))
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          (val_entry
+            (val_variable
+              (cell_path
+                (path)))))))))
+
+====
+cellpath-007-allowed-punctuation
+====
+
+$env.$var.$!@#% # comment
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_variable
+        (cell_path
+          (path)
+          (path)))))
+  (comment))

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -225,6 +225,7 @@ record-009-duration
 
 =====
 record-010-key-value-seperation
+:error
 =====
 
 {
@@ -232,18 +233,6 @@ record-010-key-value-seperation
 }
 
 -----
-
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (val_record
-        (record_body
-          (record_entry
-            (identifier)
-            (ERROR
-              (val_string))
-            (val_number)))))))
 
 =====
 record-011-immediate-comma
@@ -269,6 +258,7 @@ record-011-immediate-comma
 
 =====
 record-012-colon-in-unquoted-value
+:error
 =====
 
 {
@@ -277,25 +267,6 @@ record-012-colon-in-unquoted-value
 }
 
 -----
-
-(nu_script
-  (pipeline
-    (pipe_element
-      (val_record
-        (record_body
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_number))
-          (record_entry
-            (identifier)
-            (ERROR)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_number)))))))
 
 =====
 record-013-value-as-signed-number-or-range

--- a/test/corpus/expr/spread-operator.nu
+++ b/test/corpus/expr/spread-operator.nu
@@ -1,0 +1,108 @@
+====
+spread-001-list-literals
+====
+
+[
+  ...$dogs.names,
+  Polly
+  ...([])
+  ...[Porky Bessie]
+  ...Nemo
+]
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_list
+        (list_body
+          entry: (val_entry
+            spread: (val_variable
+              name: (identifier)
+              (cell_path
+                (path))))
+          entry: (val_entry
+            item: (val_string))
+          entry: (val_entry
+            spread: (expr_parenthesized
+              (pipeline
+                (pipe_element
+                  (val_list)))))
+          entry: (val_entry
+            spread: (val_list
+              (list_body
+                entry: (val_entry
+                  item: (val_string))
+                entry: (val_entry
+                  item: (val_string)))))
+          entry: (val_entry
+            item: (val_string)))))))
+
+====
+spread-002-record-literals
+====
+
+{
+  ...$config,
+  users: [alice bob]
+  ...{ url: example.com },
+  ...(sys mem)
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          entry: (record_entry
+            spread: (val_variable
+              name: (identifier)))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_list
+              (list_body
+                entry: (val_entry
+                  item: (val_string))
+                entry: (val_entry
+                  item: (val_string)))))
+          entry: (record_entry
+            spread: (val_record
+              (record_body
+                entry: (record_entry
+                  key: (identifier)
+                  value: (val_string)))))
+          entry: (record_entry
+            spread: (expr_parenthesized
+              (pipeline
+                (pipe_element
+                  (command
+                    head: (cmd_identifier)
+                    arg_str: (val_string)))))))))))
+
+====
+spread-003-command-arguments
+====
+
+echo ...$foo ...([]) ...[1] ...foo
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        head: (cmd_identifier)
+        arg_spread: (val_variable
+          name: (identifier))
+        arg_spread: (expr_parenthesized
+          (pipeline
+            (pipe_element
+              (val_list))))
+        arg_spread: (val_list
+          (list_body
+            entry: (val_entry
+              item: (val_number))))
+        arg_str: (val_string)))))

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -225,8 +225,10 @@ cmd --long-flag --42
     (pipe_element
       (command
         (cmd_identifier)
-        (long_flag (long_flag_identifier))
-        (long_flag (long_flag_identifier))))))
+        (long_flag
+          (long_flag_identifier))
+        (long_flag
+          (long_flag_identifier))))))
 
 ======
 cmd-011-path-string-1-dot
@@ -244,21 +246,24 @@ cargo install --path ./dir
       (command
         (cmd_identifier)
         (val_string)
-        (long_flag (long_flag_identifier))
+        (long_flag
+          (long_flag_identifier))
         (val_string))))
   (pipeline
     (pipe_element
       (command
         (cmd_identifier)
         (val_string)
-        (long_flag (long_flag_identifier))
+        (long_flag
+          (long_flag_identifier))
         (val_string))))
   (pipeline
     (pipe_element
       (command
         (cmd_identifier)
         (val_string)
-        (long_flag (long_flag_identifier))
+        (long_flag
+          (long_flag_identifier))
         (val_string)))))
 
 ======
@@ -444,6 +449,7 @@ cmd-017-string-external
 ======
 
 ^'ls'
+^$"ls"
 
 ------
 
@@ -451,7 +457,12 @@ cmd-017-string-external
   (pipeline
     (pipe_element
       (command
-        head: (val_string)))))
+        head: (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        head: (val_interpolated
+          (escaped_interpolated_content))))))
 
 ======
 cmd-018-pipe-external
@@ -483,21 +494,21 @@ bla --weird-that=this --behaved-differently=than-this --level=2
     (pipe_element
       (command
         (cmd_identifier)
-          (long_flag
-            (long_flag_equals_value
-              (long_flag_identifier)
-              (long_flag_value
-                (val_string))))
-          (long_flag
-            (long_flag_equals_value
-              (long_flag_identifier)
-              (long_flag_value
-                (val_string))))
-          (long_flag
-            (long_flag_equals_value
-              (long_flag_identifier)
-              (long_flag_value
-                (val_number))))))))
+        (long_flag
+          (long_flag_equals_value
+            (long_flag_identifier)
+            (long_flag_value
+              (val_string))))
+        (long_flag
+          (long_flag_equals_value
+            (long_flag_identifier)
+            (long_flag_value
+              (val_string))))
+        (long_flag
+          (long_flag_equals_value
+            (long_flag_identifier)
+            (long_flag_value
+              (val_number))))))))
 
 ======
 cmd-020-variable-external
@@ -1017,4 +1028,3 @@ echo +..1()
         (cmd_identifier)
         (val_string
           (expr_parenthesized))))))
-

--- a/test/corpus/pipe/redirection.nu
+++ b/test/corpus/pipe/redirection.nu
@@ -1,0 +1,91 @@
+=====
+redir-001-command-redirection
+=====
+
+echo this o> /dev/null
+echo this e>> foo
+echo this e+o>> ./foo
+echo this err+out> 32
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string)
+        (redirection
+          (val_string)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string)
+        (redirection
+          (val_string)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string)
+        (redirection
+          (val_string)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string)
+        (redirection
+          (val_string))))))
+
+=====
+redir-002-expression-redirection
+=====
+
+1 + 1 + 1 o> /dev/null
+(
+true == not false
+  o+e>> ./foo
+)
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_binary
+        (expr_binary
+          (val_number)
+          (val_number))
+        (val_number))
+      (redirection
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (expr_parenthesized
+        (pipeline
+          (pipe_element
+            (expr_binary
+              (val_bool)
+              (expr_unary
+                (val_bool)))
+            (redirection
+              (val_string))))))))
+
+=====
+redir-003-pipe-redirection
+=====
+
+echo foo e>| $in
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string)))
+    (pipe_element
+      (val_variable))))


### PR DESCRIPTION
This PR should fix #98, as well as several easy problems mentioned in #142.

I think I should keep each PR focused for better traceability, so the trickier issues related to identifier and parameters are left for later.

## Command

* [x] - val_interpolated as the external command head
  - example: `^$"($cmd)"`

## Redirection

* [x] - append ops, example `1 o>> foo`
* [x] - values redirection, example `1 + 1 o> foo`
* [x] - redirect pipes should be single token, example `cmd1 e>| cmd2`

## Parameters/command args

* [x] - spread types

## Misc

* [x] - variable as cell_path: `$foo.$bar.$baz`, it turns out `$bar` is treated as string instead.

## Changes made to the existing test cases

- `unquoted` node in `decl_use` renamed to `val_string` to align with `stmt_source`
- cases that should fail now simply tagged with `:error` since we generally don't care where the error occurs