### PR TITLE
Fix several issues of identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -9,6 +9,7 @@ module.exports = grammar({
 
   inline: ($) => [
     $._do_expression,
+    $._flag_value,
     $._item_expression,
     $._match_expression,
     $._separator,
@@ -16,7 +17,6 @@ module.exports = grammar({
     $._spread_recordish,
     $._stringish,
     $._terminator,
-    $._flag_value,
   ],
 
   // externals: $ => [
@@ -32,8 +32,7 @@ module.exports = grammar({
     [$._match_pattern_record_variable, $._value],
     [$._match_pattern_value, $._value],
     [$._parenthesized_body],
-    [$._block_body, $.parameter_pipes, $.record_body],
-    [$._block_body, $.parameter_pipes],
+    [$._block_body, $.record_body],
     [$._block_body, $.shebang],
     [$._val_number_decimal],
     [$.block, $.val_closure],
@@ -74,12 +73,46 @@ module.exports = grammar({
 
     /// Identifiers
     // NOTE:
-    // for simplicity, i used the `rust` definition of an identifier and some symbols
-    // but in `nu` the rule is way more relaxed than this
+    // probably needs an external scanner for cmd_identifier
+    // to behave exactly the same as the nushell parser
+    cmd_identifier: ($) => {
+      const excluded = "\\[\\]\\{}<>=\"`':";
+      const pattern_repeat = repeat(none_of(excluded));
+      const pattern_one = repeat1(none_of(excluded));
+      return choice(
+        token(
+          prec(PREC().low, seq(none_of(excluded + "^#$\\-"), pattern_repeat)),
+        ),
+        ...Object.values(KEYWORD()).map((x) =>
+          token(seq(x, token.immediate(pattern_repeat))),
+        ),
+        ...Object.values(MODIFIER()).map((x) =>
+          token(seq(x, token.immediate(pattern_repeat))),
+        ),
+        ...Object.values(SPECIAL()).map((x) =>
+          seq(x, token.immediate(pattern_one)),
+        ),
+        seq(
+          seq(
+            $._val_number_decimal,
+            optional(
+              choice(
+                alias($.duration_unit, "_unit"),
+                alias($.filesize_unit, "_unit"),
+              ),
+            ),
+          ),
+          token.immediate(prec(PREC().lowest, pattern_one)),
+        ),
+      );
+    },
 
-    cmd_identifier: (_$) => token(/[_\p{XID_Start}][_\-\p{XID_Continue}!?.]*/),
-
-    identifier: (_$) => token(/[_\p{XID_Start}][_\p{XID_Continue}]*/),
+    identifier: (_$) => {
+      const excluded = "\\[\\]\\-{}<>=\"`'@?,:.";
+      return token(
+        seq(none_of(excluded + "&*!^+#$"), repeat(none_of(excluded))),
+      );
+    },
 
     long_flag_identifier: (_$) =>
       token.immediate(/[0-9\p{XID_Start}_][\p{XID_Continue}?_-]*/),
@@ -161,7 +194,7 @@ module.exports = grammar({
     _multiple_types: ($) =>
       seq(
         BRACK().open_brack,
-        repeat(seq($._one_type, optional(PUNC().comma))),
+        general_body_rules("", "_one_type", "_entry_separator")($),
         BRACK().close_brack,
       ),
 
@@ -184,13 +217,7 @@ module.exports = grammar({
       ),
 
     parameter_pipes: ($) =>
-      seq(
-        repeat($._newline),
-        PUNC().pipe,
-        repeat($.parameter),
-        repeat($._newline),
-        PUNC().pipe,
-      ),
+      seq(PUNC().pipe, repeat($.parameter), repeat($._newline), PUNC().pipe),
 
     parameter: ($) =>
       prec.right(
@@ -430,7 +457,7 @@ module.exports = grammar({
           "scrutinee",
           choice($._expression, alias($.unquoted, $.val_string)),
         ),
-        BRACK().open_brace,
+        open_brace(),
         repeat($.match_arm),
         optional($.default_arm),
         repeat($._newline),
@@ -523,7 +550,7 @@ module.exports = grammar({
 
     _match_pattern_record: ($) =>
       seq(
-        BRACK().open_brace,
+        open_brace(),
         repeat(
           field(
             "entry",
@@ -573,7 +600,7 @@ module.exports = grammar({
         seq($._expression_parenthesized, optional($.redirection)),
         $._ctrl_expression_parenthesized,
         alias($.where_command_parenthesized, $.where_command),
-        alias($._command_parenthesized_body, $.command),
+        alias($._command_parenthesized, $.command),
       ),
 
     /// Scope Statements
@@ -656,23 +683,19 @@ module.exports = grammar({
 
     wild_card: (_$) => token("*"),
 
-    _command_list_body: general_body_rules(
-      "cmd",
-      "_command_name",
-      "_entry_separator",
-    ),
-
     command_list: ($) =>
       seq(
         BRACK().open_brack,
-        optional($._command_list_body),
+        optional(
+          general_body_rules("cmd", "_command_name", "_entry_separator")($),
+        ),
         BRACK().close_brack,
       ),
 
     /// Block
 
     block: ($) =>
-      seq(BRACK().open_brace, optional($._block_body), BRACK().close_brace),
+      seq(open_brace(), optional($._block_body), BRACK().close_brace),
 
     _blosure: ($) => choice(prec.dynamic(10, $.block), $.val_closure),
 
@@ -1093,7 +1116,7 @@ module.exports = grammar({
 
     val_record: ($) =>
       seq(
-        BRACK().open_brace,
+        open_brace(),
         optional($.record_body),
         BRACK().close_brace,
         optional($.cell_path),
@@ -1132,11 +1155,11 @@ module.exports = grammar({
             choice(
               // Without $.cmd_identifier, cannot correctly distinguish between record and closure
               alias($.cmd_identifier, $.identifier),
+              alias($._record_key, $.identifier),
               $.val_string,
               $.val_number,
               $.val_variable,
               $.expr_parenthesized,
-              alias($._record_key, $.identifier),
 
               // This distinguish between record keys and keywords
               ...Object.values(KEYWORD()).map((x) => alias(x, $.identifier)),
@@ -1158,22 +1181,16 @@ module.exports = grammar({
         ),
       ),
 
-    _record_key: (_$) =>
-      choice(
-        // This distinguish number and identifier starting with -/+
-        seq(
-          choice(token(OPR().minus), token(OPR().plus)),
-          token.immediate(/[^\s\n\t\r{}()\[\]"`';:,]*/),
-        ),
-        token(
-          prec(
-            PREC().lowest,
-            /[^$\s\n\t\r{}()\[\]"`';:,][^\s\n\t\r{}()\[\]"`';:,]*/,
-          ),
-        ),
-      ),
+    _record_key: (_$) => {
+      const excluded = "\\[\\]{}\"`':,";
+      const pattern_repeat = repeat(none_of(excluded));
+      // This distinguish number and identifier starting with -/+
+      return seq(
+        choice(token(OPR().minus), token(OPR().plus)),
+        token.immediate(pattern_repeat),
+      );
+    },
 
-    _val_table_body: general_body_rules("row", "val_list", "_entry_separator"),
     _table_head_separator: (_$) =>
       token(prec(PREC().higher, seq(/\s*/, PUNC().semicolon))),
 
@@ -1182,14 +1199,14 @@ module.exports = grammar({
         BRACK().open_brack,
         repeat($._newline),
         field("head", seq($.val_list, $._table_head_separator)),
-        optional($._val_table_body),
+        optional(general_body_rules("row", "val_list", "_entry_separator")($)),
         BRACK().close_brack,
         optional($.cell_path),
       ),
 
     val_closure: ($) =>
       seq(
-        BRACK().open_brace,
+        open_brace(),
         optional(field("parameters", $.parameter_pipes)),
         $._block_body,
         BRACK().close_brace,
@@ -1201,7 +1218,7 @@ module.exports = grammar({
 
     path: ($) => {
       const path = choice(
-        token(prec(PREC().low, /[^\s\n\t\r\|(){}\[\].,:;?]+/)),
+        token.immediate(prec(PREC().low, repeat1(none_of("\\[\\]{}.,:?")))),
         alias($.val_string, "quoted"),
       );
 
@@ -1216,25 +1233,8 @@ module.exports = grammar({
 
     /// Commands
 
-    command: ($) =>
-      seq(
-        choice(
-          field("head", seq(optional(PUNC().caret), $.cmd_identifier)),
-          field("head", seq(PUNC().caret, $._stringish)),
-        ),
-        prec.dynamic(10, repeat(seq($._space, optional($._cmd_arg)))),
-      ),
-
-    _command_parenthesized_body: ($) =>
-      prec.right(
-        seq(
-          choice(
-            field("head", seq(optional(PUNC().caret), $.cmd_identifier)),
-            field("head", seq(PUNC().caret, $._stringish)),
-          ),
-          prec.dynamic(10, repeat(seq($._separator, optional($._cmd_arg)))),
-        ),
-      ),
+    command: _command_rule(false),
+    _command_parenthesized: _command_rule(true),
 
     _cmd_arg: ($) =>
       choice(
@@ -1289,7 +1289,9 @@ module.exports = grammar({
         ),
       ),
 
-    _unquoted_naive: (_$) => token(/[^\s\n\t\r(){}\|;]+/),
+    long_flag_value: ($) => $._cmd_arg,
+
+    _unquoted_naive: (_$) => token(repeat1(none_of("{}"))),
     unquoted: _unquoted_rule("command"),
     _unquoted_in_list: _unquoted_rule("list"),
     _unquoted_in_record: _unquoted_rule("record"),
@@ -1324,17 +1326,20 @@ module.exports = grammar({
  * @param {string} separator
  */
 function general_body_rules(field_name, entry, separator) {
-  return (/** @type {{ [x: string]: RuleOrLiteral; }} */ $) =>
-    prec(
+  return (/** @type {{ [x: string]: RuleOrLiteral; }} */ $) => {
+    const field_entry =
+      field_name.length == 0 ? $[entry] : field(field_name, $[entry]);
+    return prec(
       PREC().higher,
       seq(
         repeat($._newline),
         // Normal entries MUST have a separator
-        repeat(seq(field(field_name, $[entry]), repeat1($[separator]))),
+        repeat(seq(field_entry, repeat1($[separator]))),
         // Final entry may or may not have separator
-        seq(field(field_name, $[entry]), repeat($[separator])),
+        seq(field_entry, repeat($[separator])),
       ),
     );
+  };
 }
 
 /**
@@ -1543,6 +1548,24 @@ function _insert_newline($, sequence, begin = false, end = true) {
 /**
  * @param {boolean} parenthesized
  */
+function _command_rule(parenthesized) {
+  return (/** @type {any} */ $) => {
+    const sep = parenthesized ? $._separator : $._space;
+    return prec.right(
+      seq(
+        choice(
+          field("head", seq(optional(PUNC().caret), $.cmd_identifier)),
+          field("head", seq(PUNC().caret, $._stringish)),
+        ),
+        prec.dynamic(10, repeat(seq(sep, optional($._cmd_arg)))),
+      ),
+    );
+  };
+}
+
+/**
+ * @param {boolean} parenthesized
+ */
 function _ctrl_try_rule(parenthesized) {
   return (/** @type {any} */ $) => {
     const seq_catch_array = [
@@ -1582,7 +1605,7 @@ function _ctrl_if_rule(parenthesized) {
     ];
     const seq_array = [
       KEYWORD().if,
-      field("condition", choice(_expr, $.identifier)),
+      field("condition", _expr),
       field("then_branch", $.block),
       optional(
         parenthesized
@@ -1680,9 +1703,10 @@ function _decimal_rule(immediate) {
   const exponent = token.immediate(/[eE][-+]?[\d_]*\d[\d_]*/);
   const digits = token.immediate(/[\d_]*\d[\d_]*/);
   const head_token = immediate ? token.immediate : token;
+  const head_digits = head_token(/[\d_]*\d[\d_]*/);
   return (/** @type {any} */ _$) =>
     choice(
-      seq(head_token(/[\d_]*\d[\d_]*/), optional(exponent)),
+      seq(head_digits, optional(exponent)),
       seq(
         token(
           seq(choice(head_token(OPR().minus), head_token(OPR().plus)), digits),
@@ -1690,7 +1714,7 @@ function _decimal_rule(immediate) {
         optional(exponent),
       ),
       seq(
-        head_token(/[\d_]*\d[\d_]*/),
+        head_digits,
         token.immediate(PUNC().dot),
         optional(digits),
         optional(exponent),
@@ -1777,15 +1801,16 @@ function _range_rule(anonymous, with_end_decimal = false) {
  * @param {string} type
  */
 function _unquoted_with_expr_rule(type) {
-  var pattern_repeat = /[^\s\n\t\r();]*/;
+  var excluded = "";
   switch (type) {
     case "list":
-      pattern_repeat = /[^\s\n\t\r()\[\];,]*/;
+      excluded += "\\[\\],";
       break;
     case "record":
-      pattern_repeat = /[^\s\n\t\r{}();:,]*/;
+      excluded += "{}:,";
       break;
   }
+  const pattern_repeat = token(repeat(none_of(excluded)));
   return ($) => {
     var unquoted_head = $.unquoted;
     switch (type) {
@@ -1824,33 +1849,31 @@ function _unquoted_with_expr_rule(type) {
  * @param {string} type
  */
 function _unquoted_rule(type) {
-  var pattern = /[^-$\s\n\t\r{}()\[\]\|"`';][^\s\n\t\r{}()\[\]\|"`';]*/;
-  var pattern_repeat = /[^\s\n\t\r{}()\[\]\|"`';]*/;
-  var pattern_repeat1 = /[^\s\n\t\r{}()\[\]\|"`';]+/;
-  var pattern_once = /[^\s\n\t\r{}()\[\]\|"`';]/;
-  var pattern_with_dot = /[^\s\n\t\r{}()\[\]\|"`';.]/;
-  var pattern_with_le = /[^\s\n\t\r{}()\[\]\|"`';=<]/;
-  var pattern_with_dollar = /[^\s\n\t\r{}()\[\]\|"`';$]/;
+  var excluded_common = "\\[\\]{}\"`'";
+  var excluded_first = excluded_common + "$";
   switch (type) {
     case "list":
-      pattern = /[^$\s\n\t\r{}()\[\]\|"`';,][^\s\n\t\r{}()\[\]\|"`';,]*/;
-      pattern_repeat = /[^\s\n\t\r{}()\[\]\|"`';,]*/;
-      pattern_repeat1 = /[^\s\n\t\r{}()\[\]\|"`';,]+/;
-      pattern_once = /[^\s\n\t\r{}()\[\]\|"`';,]/;
-      pattern_with_dot = /[^\s\n\t\r{}()\[\]\|"`';,.]/;
-      pattern_with_le = /[^\s\n\t\r{}()\[\]\|"`';,=<]/;
-      pattern_with_dollar = /[^\s\n\t\r{}()\[\]\|"`';,$]/;
+      excluded_common += ",";
       break;
     case "record":
-      pattern = /[^$\s\n\t\r{}()\[\]\|"`';:,][^\s\n\t\r{}()\[\]\|"`';:,]*/;
-      pattern_repeat = /[^\s\n\t\r{}()\[\]\|"`';:,]*/;
-      pattern_repeat1 = /[^\s\n\t\r{}()\[\]\|"`';:,]+/;
-      pattern_once = /[^\s\n\t\r{}()\[\]\|"`';:,]/;
-      pattern_with_dot = /[^\s\n\t\r{}()\[\]\|"`';:,.]/;
-      pattern_with_le = /[^\s\n\t\r{}()\[\]\|"`';:,=<]/;
-      pattern_with_dollar = /[^\s\n\t\r{}()\[\]\|"`';:,$]/;
+      excluded_common += ":,";
+      break;
+    case "command":
+      excluded_first += "-";
+      break;
+    case "identifier":
+      excluded_common += "<>=:";
+      excluded_first += "<>=\\-#^";
       break;
   }
+  const pattern_once = none_of(excluded_common);
+  const pattern = token(seq(none_of(excluded_first), repeat(pattern_once)));
+  const pattern_repeat = token(repeat(pattern_once));
+  const pattern_repeat1 = token(repeat1(pattern_once));
+  const pattern_with_dot = none_of(excluded_common + ".");
+  const pattern_with_le = none_of(excluded_common + "<=");
+  const pattern_with_dollar = none_of(excluded_common + "$");
+
   // because this catches almost anything, we want to ensure it is
   // picked as the a last resort after everything else has failed.
   // so we give it a ridiculously low precedence and place it at the
@@ -2044,6 +2067,12 @@ function BRACK() {
   };
 }
 
+// group open_brace and following whitespace/newline together
+// so they won't participate in conflicts resolving between record and block
+function open_brace() {
+  return alias(token(seq(BRACK().open_brace, /\s*/)), BRACK().open_brace);
+}
+
 // operators
 function OPR() {
   return {
@@ -2217,4 +2246,16 @@ function FLAT_TYPES() {
   ];
 
   return choice(...types);
+}
+
+/**
+ * Returns a regular expression that matches any character except the ones
+ * provided.
+ *
+ * @param  {string} excluded
+ *
+ * @returns {RegExp}
+ */
+function none_of(excluded = "") {
+  return new RegExp("[^\\s\\r\\n\\t\\|();" + excluded + "]");
 }

--- a/grammar.js
+++ b/grammar.js
@@ -1289,8 +1289,6 @@ module.exports = grammar({
         ),
       ),
 
-    long_flag_value: ($) => $._cmd_arg,
-
     _unquoted_naive: (_$) => token(repeat1(none_of("{}"))),
     unquoted: _unquoted_rule("command"),
     _unquoted_in_list: _unquoted_rule("list"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -12444,10 +12444,6 @@
         }
       ]
     },
-    "long_flag_value": {
-      "type": "SYMBOL",
-      "name": "_cmd_arg"
-    },
     "_unquoted_naive": {
       "type": "TOKEN",
       "content": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -841,17 +841,1037 @@
       ]
     },
     "cmd_identifier": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "[_\\p{XID_Start}][_\\-\\p{XID_Continue}!?.]*"
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": -1,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':^#$\\-]"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "def"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "alias"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "use"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "export-env"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "extern"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "module"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "let"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "let-env"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "mut"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "const"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "hide"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "hide-env"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "source"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "source-env"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "overlay"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "register"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "for"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "loop"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "while"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "error"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "do"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "if"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "else"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "try"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "catch"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "match"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "break"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "continue"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "return"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "as"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "in"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "hide"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "list"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "new"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "use"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "make"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "export"
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "true"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "false"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "null"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[nN][aA][nN]"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_val_number_decimal"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "duration_unit"
+                          },
+                          "named": false,
+                          "value": "_unit"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "filesize_unit"
+                          },
+                          "named": false,
+                          "value": "_unit"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": -69,
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\{}<>=\"`':]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
     "identifier": {
       "type": "TOKEN",
       "content": {
-        "type": "PATTERN",
-        "value": "[_\\p{XID_Start}][_\\p{XID_Continue}]*"
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.&*!^+#$]"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PATTERN",
+              "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.]"
+            }
+          }
+        ]
       }
     },
     "long_flag_identifier": {
@@ -1311,23 +2331,50 @@
           "value": "["
         },
         {
-          "type": "REPEAT",
+          "type": "PREC",
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_one_type"
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_newline"
+                }
               },
               {
-                "type": "CHOICE",
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_one_type"
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_entry_separator"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "SEQ",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": ","
+                    "type": "SYMBOL",
+                    "name": "_one_type"
                   },
                   {
-                    "type": "BLANK"
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_entry_separator"
+                    }
                   }
                 ]
               }
@@ -1397,13 +2444,6 @@
     "parameter_pipes": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_newline"
-          }
-        },
         {
           "type": "STRING",
           "value": "|"
@@ -2627,17 +3667,8 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_expression"
           }
         },
         {
@@ -2719,17 +3750,8 @@
           "type": "FIELD",
           "name": "condition",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression_parenthesized"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_expression_parenthesized"
           }
         },
         {
@@ -2856,7 +3878,24 @@
           }
         },
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\s*"
+                }
+              ]
+            }
+          },
+          "named": false,
           "value": "{"
         },
         {
@@ -3285,7 +4324,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\s*"
+                }
+              ]
+            }
+          },
+          "named": false,
           "value": "{"
         },
         {
@@ -3585,7 +4641,7 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "_command_parenthesized_body"
+            "name": "_command_parenthesized"
           },
           "named": true,
           "value": "command"
@@ -3929,65 +4985,6 @@
         "value": "*"
       }
     },
-    "_command_list_body": {
-      "type": "PREC",
-      "value": 20,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "cmd",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_command_name"
-                  }
-                },
-                {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_entry_separator"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "cmd",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_command_name"
-                }
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_entry_separator"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
     "command_list": {
       "type": "SEQ",
       "members": [
@@ -3999,8 +4996,63 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_command_list_body"
+              "type": "PREC",
+              "value": 20,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "FIELD",
+                          "name": "cmd",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_command_name"
+                          }
+                        },
+                        {
+                          "type": "REPEAT1",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_entry_separator"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "cmd",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_command_name"
+                        }
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_entry_separator"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
             },
             {
               "type": "BLANK"
@@ -4017,7 +5069,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\s*"
+                }
+              ]
+            }
+          },
+          "named": false,
           "value": "{"
         },
         {
@@ -9857,7 +10926,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\s*"
+                }
+              ]
+            }
+          },
+          "named": false,
           "value": "{"
         },
         {
@@ -10068,6 +11154,15 @@
                     "value": "identifier"
                   },
                   {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_record_key"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
                     "type": "SYMBOL",
                     "name": "val_string"
                   },
@@ -10082,15 +11177,6 @@
                   {
                     "type": "SYMBOL",
                     "name": "expr_parenthesized"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_record_key"
-                    },
-                    "named": true,
-                    "value": "identifier"
                   },
                   {
                     "type": "ALIAS",
@@ -10489,110 +11575,38 @@
       ]
     },
     "_record_key": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "-"
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "+"
-                  }
-                }
-              ]
+              "type": "TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "-"
+              }
             },
             {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+                "type": "STRING",
+                "value": "+"
               }
             }
           ]
         },
         {
-          "type": "TOKEN",
+          "type": "IMMEDIATE_TOKEN",
           "content": {
-            "type": "PREC",
-            "value": -69,
+            "type": "REPEAT",
             "content": {
               "type": "PATTERN",
-              "value": "[^$\\s\\n\\t\\r{}()\\[\\]\"`';:,][^\\s\\n\\t\\r{}()\\[\\]\"`';:,]*"
+              "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
             }
           }
         }
       ]
-    },
-    "_val_table_body": {
-      "type": "PREC",
-      "value": 20,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "row",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "val_list"
-                  }
-                },
-                {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_entry_separator"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "row",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "val_list"
-                }
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_entry_separator"
-                }
-              }
-            ]
-          }
-        ]
-      }
     },
     "_table_head_separator": {
       "type": "TOKEN",
@@ -10649,8 +11663,63 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_val_table_body"
+              "type": "PREC",
+              "value": 20,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "FIELD",
+                          "name": "row",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "val_list"
+                          }
+                        },
+                        {
+                          "type": "REPEAT1",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_entry_separator"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "row",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "val_list"
+                        }
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_entry_separator"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
             },
             {
               "type": "BLANK"
@@ -10679,7 +11748,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\s*"
+                }
+              ]
+            }
+          },
+          "named": false,
           "value": "{"
         },
         {
@@ -10739,13 +11825,16 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "TOKEN",
+                    "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PREC",
                       "value": -1,
                       "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\n\\t\\r\\|(){}\\[\\].,:;?]+"
+                        "type": "REPEAT1",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}.,:?]"
+                        }
                       }
                     }
                   },
@@ -10771,13 +11860,16 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "TOKEN",
+                        "type": "IMMEDIATE_TOKEN",
                         "content": {
                           "type": "PREC",
                           "value": -1,
                           "content": {
-                            "type": "PATTERN",
-                            "value": "[^\\s\\n\\t\\r\\|(){}\\[\\].,:;?]+"
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "PATTERN",
+                              "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}.,:?]"
+                            }
                           }
                         }
                       },
@@ -10804,86 +11896,90 @@
       ]
     },
     "command": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "head",
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "head",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "^"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "cmd_identifier"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "head",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "^"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_stringish"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "PREC_DYNAMIC",
+            "value": 10,
+            "content": {
+              "type": "REPEAT",
               "content": {
                 "type": "SEQ",
                 "members": [
                   {
+                    "type": "SYMBOL",
+                    "name": "_space"
+                  },
+                  {
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "^"
+                        "type": "SYMBOL",
+                        "name": "_cmd_arg"
                       },
                       {
                         "type": "BLANK"
                       }
                     ]
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "cmd_identifier"
                   }
                 ]
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "head",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "^"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_stringish"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "PREC_DYNAMIC",
-          "value": 10,
-          "content": {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_space"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_cmd_arg"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
             }
           }
-        }
-      ]
+        ]
+      }
     },
-    "_command_parenthesized_body": {
+    "_command_parenthesized": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -11348,11 +12444,18 @@
         }
       ]
     },
+    "long_flag_value": {
+      "type": "SYMBOL",
+      "name": "_cmd_arg"
+    },
     "_unquoted_naive": {
       "type": "TOKEN",
       "content": {
-        "type": "PATTERN",
-        "value": "[^\\s\\n\\t\\r(){}\\|;]+"
+        "type": "REPEAT1",
+        "content": {
+          "type": "PATTERN",
+          "value": "[^\\s\\r\\n\\t\\|();{}]"
+        }
       }
     },
     "unquoted": {
@@ -11369,8 +12472,23 @@
               "content": {
                 "type": "TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^-$\\s\\n\\t\\r{}()\\[\\]\\|\"`';][^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$-]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -11389,7 +12507,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'.]"
                     }
                   },
                   {
@@ -11404,8 +12522,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11424,14 +12548,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';.]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'.]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11447,14 +12577,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';=<]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'<=]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11479,14 +12615,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';$]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11508,8 +12650,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11545,7 +12693,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
                     }
                   },
                   {
@@ -11572,7 +12720,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'.]"
                     }
                   },
                   {
@@ -11619,14 +12767,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11648,8 +12802,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11664,8 +12824,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';]+"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT1",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
+                  }
                 }
               }
             ]
@@ -11687,8 +12853,23 @@
               "content": {
                 "type": "TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^$\\s\\n\\t\\r{}()\\[\\]\\|\"`';,][^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -11707,7 +12888,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',.]"
                     }
                   },
                   {
@@ -11722,8 +12903,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11742,14 +12929,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,.]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',.]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11765,14 +12958,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,=<]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',<=]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11797,14 +12996,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,$]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',$]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11826,8 +13031,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11863,7 +13074,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
                     }
                   },
                   {
@@ -11890,7 +13101,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',.]"
                     }
                   },
                   {
@@ -11937,14 +13148,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11966,8 +13183,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -11982,8 +13205,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';,]+"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT1",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
+                  }
                 }
               }
             ]
@@ -12005,8 +13234,23 @@
               "content": {
                 "type": "TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^$\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,][^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -12025,7 +13269,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,.]"
                     }
                   },
                   {
@@ -12040,8 +13284,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12060,14 +13310,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,.]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,.]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12083,14 +13339,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,=<]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,<=]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12115,14 +13377,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,$]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,$]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12144,8 +13412,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12181,7 +13455,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
                     }
                   },
                   {
@@ -12208,7 +13482,7 @@
                     "type": "IMMEDIATE_TOKEN",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,.]"
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,.]"
                     }
                   },
                   {
@@ -12255,14 +13529,20 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]"
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
                 }
               },
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12284,8 +13564,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]*"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12300,8 +13586,14 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\n\\t\\r{}()\\[\\]\\|\"`';:,]+"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "REPEAT1",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
+                  }
                 }
               }
             ]
@@ -12361,8 +13653,14 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\n\\t\\r();]*"
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[^\\s\\r\\n\\t\\|();]"
+                          }
+                        }
                       }
                     },
                     {
@@ -12385,8 +13683,14 @@
           {
             "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "PATTERN",
-              "value": "[^\\s\\n\\t\\r();]*"
+              "type": "TOKEN",
+              "content": {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();]"
+                }
+              }
             }
           }
         ]
@@ -12444,8 +13748,14 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\n\\t\\r()\\[\\];,]*"
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
+                          }
+                        }
                       }
                     },
                     {
@@ -12468,8 +13778,14 @@
           {
             "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "PATTERN",
-              "value": "[^\\s\\n\\t\\r()\\[\\];,]*"
+              "type": "TOKEN",
+              "content": {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
+                }
+              }
             }
           }
         ]
@@ -12527,8 +13843,14 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\n\\t\\r{}();:,]*"
+                        "type": "TOKEN",
+                        "content": {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[^\\s\\r\\n\\t\\|();{}:,]"
+                          }
+                        }
                       }
                     },
                     {
@@ -12551,8 +13873,14 @@
           {
             "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "PATTERN",
-              "value": "[^\\s\\n\\t\\r{}();:,]*"
+              "type": "TOKEN",
+              "content": {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\s\\r\\n\\t\\|();{}:,]"
+                }
+              }
             }
           }
         ]
@@ -12741,12 +14069,7 @@
     ],
     [
       "_block_body",
-      "parameter_pipes",
       "record_body"
-    ],
-    [
-      "_block_body",
-      "parameter_pipes"
     ],
     [
       "_block_body",
@@ -12783,14 +14106,14 @@
   "externals": [],
   "inline": [
     "_do_expression",
+    "_flag_value",
     "_item_expression",
     "_match_expression",
     "_separator",
     "_spread_listish",
     "_spread_recordish",
     "_stringish",
-    "_terminator",
-    "_flag_value"
+    "_terminator"
   ],
   "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -184,6 +184,11 @@
     }
   },
   {
+    "type": "cmd_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "collection_type",
     "named": true,
     "fields": {
@@ -707,10 +712,6 @@
           },
           {
             "type": "expr_unary",
-            "named": true
-          },
-          {
-            "type": "identifier",
             "named": true
           },
           {
@@ -3856,7 +3857,7 @@
     "fields": {
       "type": {
         "multiple": true,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "collection_type",
@@ -5674,10 +5675,6 @@
   {
     "type": "closure",
     "named": false
-  },
-  {
-    "type": "cmd_identifier",
-    "named": true
   },
   {
     "type": "cond",

--- a/test/corpus/expr/identifier.nu
+++ b/test/corpus/expr/identifier.nu
@@ -1,0 +1,234 @@
+====
+id-001-variable
+====
+
+let foo = 1
+let 42 = 1
+$foo
+$42
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number))))
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number))))
+  (pipeline
+    (pipe_element
+      (val_variable
+        (identifier))))
+  (pipeline
+    (pipe_element
+      (val_variable
+        (identifier)))))
+
+====
+id-002-variable-invalid-dash
+:error
+====
+
+let foo-bar = 1
+
+-----
+
+
+
+====
+id-003-variable-invalid-hash
+:error
+====
+
+let #foo = 1
+
+-----
+
+
+
+====
+id-004-variable-unicode
+====
+
+let こ = 1;
+let 🙌 = 1
+$こ
+$🙌
+
+-----
+
+(nu_script
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number))))
+  (stmt_let
+    (identifier)
+    (pipeline
+      (pipe_element
+        (val_number))))
+  (pipeline
+    (pipe_element
+      (val_variable
+        (identifier))))
+  (pipeline
+    (pipe_element
+      (val_variable
+        (identifier)))))
+
+====
+id-005-def
+====
+
+def foo [
+  参
+🤖
+  ...0
+] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier))
+      (parameter
+        (identifier))
+      (parameter
+        (param_rest
+          (identifier))))
+    (block)))
+
+====
+cmd-id-001-external
+====
+
+^tree-sitter
+^7z
+^g++
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)))))
+
+====
+cmd-id-002-command-vs-value
+====
+
+# values
+null
+7b
+nan
+# commands
+g++
+7z
+7mss
+truee
+nann
+nulll
+users
+
+-----
+
+(nu_script
+  (comment)
+  (pipeline
+    (pipe_element
+      (val_nothing)))
+  (pipeline
+    (pipe_element
+      (val_filesize
+        (val_number)
+        (filesize_unit))))
+  (pipeline
+    (pipe_element
+      (val_number)))
+  (comment)
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)))))
+
+====
+cmd-id-003-path
+====
+
+/usr/bin/env nu
+~/foo.nu
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)))))
+
+====
+cmd-id-004-unicode
+====
+
+def 🤖👀 [] {}
+
+🤖👀
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks)
+    (block))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)))))

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -234,6 +234,8 @@ record-010-key-value-seperation
 
 -----
 
+
+
 =====
 record-011-immediate-comma
 =====
@@ -267,6 +269,8 @@ record-012-colon-in-unquoted-value
 }
 
 -----
+
+
 
 =====
 record-013-value-as-signed-number-or-range
@@ -445,8 +449,12 @@ k4.9: 1...()}
 record-015-separated-colon-vs-closure
 =====
 
-{echo : 1}
+{echo% : 1}
 {echo 1:}
+{is-empty}
+{
+  echo : 1
+}
 
 -----
 
@@ -465,4 +473,18 @@ record-015-separated-colon-vs-closure
           (pipe_element
             (command
               (cmd_identifier)
-              (val_string))))))))
+              (val_string)))))))
+  (pipeline
+    (pipe_element
+      (val_closure
+        (pipeline
+          (pipe_element
+            (command
+              (cmd_identifier)))))))
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          (record_entry
+            (identifier)
+            (val_number)))))))


### PR DESCRIPTION
This PR fixes most of the remaining issues related to identifiers as reported in #142 .

```nushell
# values
null
7b
nan
# commands
g++
7z
7mss
truee
```

It's still not perfect, nushell handles special characters like `-, #, ., ()` in identifiers very dynamically.
I think this is the time to finally resort to an external scanner for further accuracy.