### PR TITLE
chore: migrate to new tree-sitter.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,6 @@
     "tree-sitter-cli": "^0.22.5",
     "prebuildify": "^6.0.0"
   },
-  "tree-sitter": [
-    {
-      "scope": "source.nu",
-      "file-types": [
-        "nu"
-      ],
-      "highlights": "queries/nu/highlights.scm",
-      "injections": "queries/nu/injections.scm"
-    }
-  ],
   "files": [
     "grammar.js",
     "binding.gyp",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,36 @@
+{
+  "grammars": [
+    {
+      "name": "nu",
+      "camelcase": "Nu",
+      "scope": "source.nu",
+      "path": ".",
+      "file-types": [
+        "nu"
+      ],
+      "highlights": "queries/nu/highlights.scm",
+      "injections": "queries/nu/injections.scm"
+    }
+  ],
+  "metadata": {
+    "version": "0.0.1",
+    "license": "MIT",
+    "description": "nu-lang",
+    "authors": [
+      {
+        "name": "The Nushell Contributors"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/tree-sitter/tree-sitter-nu"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
tree-sitter greeted me with this message:
```
Warning: your package.json's `tree-sitter` field has been automatically migrated to the new `tree-sitter.json` config file
For more information, visit https://tree-sitter.github.io/tree-sitter/creating-parsers
```

In this PR, I want to migrate tree-sitter's config to the new format.