### PR TITLE
Fix: raw string with leading whitespaces

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -9,6 +9,7 @@ module.exports = grammar({
 
   inline: ($) => [
     $._do_expression,
+    $._flag,
     $._flag_value,
     $._item_expression,
     $._match_expression,
@@ -273,14 +274,12 @@ module.exports = grammar({
           token.immediate(BRACK().open_angle),
           repeat(
             seq(
-              seq(
-                key,
-                optional(
-                  seq(
-                    PUNC().colon,
-                    $._all_type,
-                    field("completion", optional($.param_cmd)),
-                  ),
+              key,
+              optional(
+                seq(
+                  PUNC().colon,
+                  $._all_type,
+                  field("completion", optional($.param_cmd)),
                 ),
               ),
               optional(PUNC().comma),
@@ -419,7 +418,7 @@ module.exports = grammar({
         PREC().low,
         seq(
           KEYWORD().do,
-          optional(seq(repeat($._flags_parenthesized))),
+          repeat($._flags_parenthesized),
           repeat1($._separator),
           choice($._blosure, $.val_variable),
           repeat(seq(repeat($._newline), $._do_expression)),
@@ -1283,7 +1282,7 @@ module.exports = grammar({
         ),
       ),
 
-    _flag: ($) => prec.right(5, choice($.short_flag, $.long_flag)),
+    _flag: ($) => choice($.short_flag, $.long_flag),
 
     _flags_parenthesized: ($) => seq(repeat1($._separator), $._flag),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2955,66 +2955,61 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SEQ",
+                    "type": "FIELD",
+                    "name": "key",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "val_string"
+                          },
+                          "named": true,
+                          "value": "identifier"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "FIELD",
-                        "name": "key",
-                        "content": {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "identifier"
-                            },
-                            {
-                              "type": "ALIAS",
-                              "content": {
-                                "type": "SYMBOL",
-                                "name": "val_string"
-                              },
-                              "named": true,
-                              "value": "identifier"
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "CHOICE",
+                        "type": "SEQ",
                         "members": [
                           {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ":"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "_all_type"
-                              },
-                              {
-                                "type": "FIELD",
-                                "name": "completion",
-                                "content": {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SYMBOL",
-                                      "name": "param_cmd"
-                                    },
-                                    {
-                                      "type": "BLANK"
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
+                            "type": "STRING",
+                            "value": ":"
                           },
                           {
-                            "type": "BLANK"
+                            "type": "SYMBOL",
+                            "name": "_all_type"
+                          },
+                          {
+                            "type": "FIELD",
+                            "name": "completion",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "param_cmd"
+                                },
+                                {
+                                  "type": "BLANK"
+                                }
+                              ]
+                            }
                           }
                         ]
+                      },
+                      {
+                        "type": "BLANK"
                       }
                     ]
                   },
@@ -3598,24 +3593,11 @@
             "value": "do"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_flags_parenthesized"
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flags_parenthesized"
+            }
           },
           {
             "type": "REPEAT1",
@@ -14971,21 +14953,17 @@
       ]
     },
     "_flag": {
-      "type": "PREC_RIGHT",
-      "value": 5,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "short_flag"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "long_flag"
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "short_flag"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "long_flag"
+        }
+      ]
     },
     "_flags_parenthesized": {
       "type": "SEQ",
@@ -16111,6 +16089,7 @@
   ],
   "inline": [
     "_do_expression",
+    "_flag",
     "_flag_value",
     "_item_expression",
     "_match_expression",

--- a/test/corpus/expr/raw-strings.nu
+++ b/test/corpus/expr/raw-strings.nu
@@ -2,6 +2,7 @@
 raw-strings-001-simple
 =====
 
+  r#'string'#
 r#'string'#
 
 -----
@@ -10,9 +11,15 @@ r#'string'#
   (pipeline
     (pipe_element
       (val_string
-          (raw_string_begin)
-          (raw_string_content)
-          (raw_string_end)))))
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end))))
+  (pipeline
+    (pipe_element
+      (val_string
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end)))))
 
 =====
 raw-strings-002-simple
@@ -26,9 +33,9 @@ r##'raw string: r#'bla'#'##
   (pipeline
     (pipe_element
       (val_string
-          (raw_string_begin)
-          (raw_string_content)
-          (raw_string_end)))))
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end)))))
 
 =====
 raw-strings-003-simple
@@ -42,9 +49,9 @@ r#####'string'#####
   (pipeline
     (pipe_element
       (val_string
-          (raw_string_begin)
-          (raw_string_content)
-          (raw_string_end)))))
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end)))))
 
 =====
 raw-strings-004-with-ticks-and-tags
@@ -58,9 +65,9 @@ r#####'string '#'##'#####
   (pipeline
     (pipe_element
       (val_string
-          (raw_string_begin)
-          (raw_string_content)
-          (raw_string_end)))))
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end)))))
 
 =====
 raw-strings-005-empty-string
@@ -74,6 +81,6 @@ r#''#
   (pipeline
     (pipe_element
       (val_string
-          (raw_string_begin)
-          (raw_string_content)
-          (raw_string_end)))))
+        (raw_string_begin)
+        (raw_string_content)
+        (raw_string_end)))))


### PR DESCRIPTION
This PR fixes #157 .
The problem is rooted in my [review suggestion](https://github.com/nushell/tree-sitter-nu/pull/117#discussion_r1851234358), so the change is reverted.

But I don't get why, how is whitespaces automatically skipped by `extras` for `$._str_double_quotes`, but not `$._raw_string`. 
@mrdgo do you have any idea?