### PR TITLE
Fix: remove `lexer->log` calls for better compatibility

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -77,20 +77,16 @@ void tree_sitter_nu_external_scanner_deserialize(
 }
 
 static bool scan_raw_string_begin(TSLexer *lexer, Scanner *s) {
-    lexer->log(lexer, "BEGIN\n");
     // scan for r#' r##' or more #
     skip_whitespace(lexer);
 
     if (lexer->lookahead != 'r') {
         return false;
     }
-    lexer->log(lexer, "Detected 'r'.\n");
     adv;
     uint8_t level = consume_chars(lexer, '#');
-    lexer->log(lexer, "num #: %i\n", level);
     if (lexer->lookahead == '\'') {
         adv;
-        lexer->log(lexer, "Detected level: %i\n", level);
         s->level = level;
         return true;
     }
@@ -99,17 +95,13 @@ static bool scan_raw_string_begin(TSLexer *lexer, Scanner *s) {
 
 static bool scan_raw_string_content(TSLexer *lexer, Scanner *s) {
     uint32_t len = 0;
-    lexer->log(lexer, "CONTENT\n");
     while (!eof) {
         uint32_t num = consume_until(lexer, '\'');
-        lexer->log(lexer, "Set mark\n");
         lexer->mark_end(lexer);
         len += num;
         adv;
         uint8_t level = consume_chars(lexer, '#');
-        lexer->log(lexer, "Consumed [%i] #\n", level);
         if (level == s->level) {
-            lexer->log(lexer, "Detected end\n" );
             return true;
         }
     }
@@ -118,7 +110,6 @@ static bool scan_raw_string_content(TSLexer *lexer, Scanner *s) {
 }
 
 static bool scan_raw_string_end(TSLexer *lexer, Scanner *s) {
-    lexer->log(lexer, "END\n");
     // HINT: scan_raw_string_content already determines the content's length
     // so we only advance to the end of the delimiter and return true.
     adv;
@@ -139,7 +130,6 @@ bool tree_sitter_nu_external_scanner_scan(
     }
 
     Scanner *s = (Scanner *) payload;
-    lexer->log(lexer, "Nu Scanner: level [%i]\n", s->level);
 
     if (valid_symbols[RAW_STRING_BEGIN] && s->level == 0) {
         lexer->result_symbol = RAW_STRING_BEGIN;


### PR DESCRIPTION
Hopefully this PR fixes recent reported crashes on discord:

```
woosaaahh — Today at 4:57 AM
Finaaaaaally !!!
After debugging nvim-treesitter, neovim lua code for tree-sitter then hours of manual bisect + compiling neovim, 
I think a found an explanation for my neovim crashes !

This commit is the first one that prevent my Neovim from crashing :
https://github.com/neovim/neovim/commit/664de5ea971440f24e3e7e3618786d01fbca6025
It bumps treesitter dependency from v0.22.6 to v0.23.0.

According this https://github.com/neovim/neovim/blob/release-0.10/cmake.deps/deps.txt#L56 ,
the latest stable release (v0.10.2) still uses treesitter v0.22.6.

My understanding is that all languages grammars/parsers/scanners that use 
treesitter v0.23.0 and more are not compatible with nvim v0.10.2 and below.

So with that in mind, I have 2 solutions :
1°) using nvim nightly and use the latest tree-sitter-nu
or
2°) keep using nvim v0.10.2 but using older version of tree-sitter-nu with custom nvim-treesitter config 
that point to a local copy of tree-sitter-nu (solution that I didn't tried yet)
https://github.com/nushell/tree-sitter-nu/commit/082a7c7df7db460da6b280c9f902bf2b19a2f423

EDIT: For solution 2°), I didn't find yet any compatible versions between neovim v0.10.2, nvim-treesitter and tree-sitter-nu,
so I'll use solution 1°) and neovim nightly until my brain figure it out
```

<img width="501" alt="image" src="https://github.com/user-attachments/assets/ea0e9668-1e8a-44ac-84af-e5d2f5265dde">
