### PR TITLE
fix: multiline collection type and more

### DIFF
--- a/internal.txt
+++ b/internal.txt
@@ -73,7 +73,6 @@ encode base32
 encode base32hex
 encode base64
 encode hex
-error make
 explore ir
 format date
 format duration

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2709,7 +2709,7 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_unquoted_in_list"
+                  "name": "_unquoted_in_record"
                 },
                 "named": true,
                 "value": "val_string"
@@ -2718,7 +2718,7 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_unquoted_in_list_with_expr"
+                  "name": "_unquoted_in_record_with_expr"
                 },
                 "named": true,
                 "value": "val_string"
@@ -2950,83 +2950,178 @@
               }
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "key",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "val_string"
-                          },
-                          "named": true,
-                          "value": "identifier"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "CHOICE",
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PREC",
+                  "value": 20,
+                  "content": {
+                    "type": "SEQ",
                     "members": [
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_newline"
+                        }
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "FIELD",
+                                  "name": "key",
+                                  "content": {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "identifier"
+                                      },
+                                      {
+                                        "type": "ALIAS",
+                                        "content": {
+                                          "type": "SYMBOL",
+                                          "name": "val_string"
+                                        },
+                                        "named": true,
+                                        "value": "identifier"
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": ":"
+                                        },
+                                        {
+                                          "type": "SYMBOL",
+                                          "name": "_all_type"
+                                        },
+                                        {
+                                          "type": "FIELD",
+                                          "name": "completion",
+                                          "content": {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SYMBOL",
+                                                "name": "param_cmd"
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "BLANK"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "REPEAT1",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "_entry_separator"
+                              }
+                            }
+                          ]
+                        }
+                      },
                       {
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "STRING",
-                            "value": ":"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_all_type"
-                          },
-                          {
                             "type": "FIELD",
-                            "name": "completion",
+                            "name": "key",
                             "content": {
                               "type": "CHOICE",
                               "members": [
                                 {
                                   "type": "SYMBOL",
-                                  "name": "param_cmd"
+                                  "name": "identifier"
                                 },
                                 {
-                                  "type": "BLANK"
+                                  "type": "ALIAS",
+                                  "content": {
+                                    "type": "SYMBOL",
+                                    "name": "val_string"
+                                  },
+                                  "named": true,
+                                  "value": "identifier"
                                 }
                               ]
                             }
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ":"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_all_type"
+                                  },
+                                  {
+                                    "type": "FIELD",
+                                    "name": "completion",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "SYMBOL",
+                                          "name": "param_cmd"
+                                        },
+                                        {
+                                          "type": "BLANK"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
                           }
                         ]
                       },
                       {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "BLANK"
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_entry_separator"
+                        }
                       }
                     ]
                   }
-                ]
-              }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",
@@ -10784,6 +10879,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "val_range"
+        },
+        {
+          "type": "SYMBOL",
           "name": "expr_binary"
         },
         {
@@ -10802,6 +10901,10 @@
         {
           "type": "SYMBOL",
           "name": "_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_range"
         },
         {
           "type": "ALIAS",
@@ -14941,10 +15044,6 @@
                             },
                             {
                               "type": "STRING",
-                              "value": "error make"
-                            },
-                            {
-                              "type": "STRING",
                               "value": "explore ir"
                             },
                             {
@@ -17131,10 +17230,6 @@
                             },
                             {
                               "type": "STRING",
-                              "value": "error make"
-                            },
-                            {
-                              "type": "STRING",
                               "value": "explore ir"
                             },
                             {
@@ -19140,35 +19235,30 @@
           ]
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_space"
-            },
-            {
-              "type": "FIELD",
-              "name": "file_path",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_unquoted_naive"
-                    },
-                    "named": true,
-                    "value": "val_string"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_stringish"
-                  }
-                ]
+          "type": "SYMBOL",
+          "name": "_space"
+        },
+        {
+          "type": "FIELD",
+          "name": "file_path",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_unquoted_naive"
+                },
+                "named": true,
+                "value": "val_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_stringish"
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1696,6 +1696,10 @@
             "named": true
           },
           {
+            "type": "val_range",
+            "named": true
+          },
+          {
             "type": "val_record",
             "named": true
           },
@@ -1885,6 +1889,10 @@
           },
           {
             "type": "val_number",
+            "named": true
+          },
+          {
+            "type": "val_range",
             "named": true
           },
           {

--- a/test/corpus/ctrl/error.nu
+++ b/test/corpus/ctrl/error.nu
@@ -1,0 +1,11 @@
+=====
+error-001-smoke-test
+=====
+
+error make {}
+
+-----
+
+(nu_script
+  (ctrl_error
+    (val_record)))

--- a/test/corpus/decl/def.nu
+++ b/test/corpus/decl/def.nu
@@ -972,6 +972,7 @@ def test [
   y: string@"cmd",
   --zero(-z): list<string@cmd>
 = hello,
+  --one=one: int
 ] {}
 
 -----
@@ -1004,5 +1005,42 @@ def test [
             completion: (param_cmd
               unquoted_name: (cmd_identifier))))
         (param_value
-          param_value: (val_string))))
+          param_value: (val_string)))
+      (parameter
+        param_long_flag: (param_long_flag
+          (long_flag_identifier))
+        (param_value
+          param_value: (val_string))
+        (param_type
+          type: (flat_type))))
     body: (block)))
+
+======
+def-034-types-multiline-collection
+======
+
+def open-pr [
+    pr: record<
+        branch: string
+        title: string
+        body: string
+    >
+] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)
+            (flat_type)
+            (identifier)
+            (flat_type)
+            (identifier)
+            (flat_type)))))
+    (block)))

--- a/test/corpus/expr/binary-expr.nu
+++ b/test/corpus/expr/binary-expr.nu
@@ -203,3 +203,20 @@ and true
                   (val_number)
                   (val_number)))
               (val_bool))))))))
+
+====
+binary-expr-010-range
+====
+
+1 in 1..=3
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (expr_binary
+        (val_number)
+        (val_range
+          (val_number)
+          (val_number))))))


### PR DESCRIPTION
This PR fixes:

1. `param_value` before `param_type`, e.g. `--param=value: string`
2. `error make {}` by removing it from internal.txt
3. `val_range` in binary expression, e.g. `1 in 1..3`
4. multiline type signature, e.g.

```nushell
table<
foo: string
>
```