### PR TITLE
fix: whitespaces issue of `overlay use`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -15,7 +15,6 @@ module.exports = grammar({
 
   inline: ($) => [
     $._do_expression,
-    $._flag,
     $._flag_value,
     $._item_expression,
     $._match_expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -20343,7 +20343,6 @@
   ],
   "inline": [
     "_do_expression",
-    "_flag",
     "_flag_value",
     "_item_expression",
     "_match_expression",


### PR DESCRIPTION
Before:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/09b8a434-d46c-4a6e-b1b9-3eaf4dc4c033" />
<img width="540" alt="image" src="https://github.com/user-attachments/assets/b3430d31-40cc-4a85-ad85-131916d8c467" />

After the fix:
<img width="540" alt="image" src="https://github.com/user-attachments/assets/47bdd814-cede-455b-9a59-1bddd26afd24" />
<img width="540" alt="image" src="https://github.com/user-attachments/assets/968fe8e4-f70f-4659-98a9-936f5f06b8c3" />

Still, I don't have enough understanding of why it works, any help or explanation is welcome.
