### PR TITLE
fix: parameter comment doc highlight

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -311,13 +311,9 @@ key: (identifier) @property
 
 (shebang) @keyword.directive
 (comment) @comment
-(
- (comment)+ @comment.documentation
- .
- (decl_def)
-)
-(
- (parameter)
- .
- (comment) @comment.documentation
-)
+((comment)+ @comment.documentation @spell
+  .
+  (decl_def))
+
+(parameter
+  (comment) @comment.documentation @spell)


### PR DESCRIPTION
The doc comment string of a parameter is actually parsed as a child node

Forgot to check it in #171 .