### PR TITLE
feat: highlight more redirection operators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1305,7 +1305,7 @@ module.exports = grammar({
         ),
       ),
 
-    _unquoted_naive: (_$) => token(repeat1(none_of("{}"))),
+    _unquoted_naive: (_$) => token(prec(PREC().low, repeat1(none_of("{}")))),
     unquoted: _unquoted_rule("command"),
     _unquoted_in_list: _unquoted_rule("list"),
     _unquoted_in_record: _unquoted_rule("record"),

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -182,6 +182,14 @@ file_path: (val_string) @variable.parameter
     "e>"   "err>"
     "e+o>" "err+out>"
     "o+e>" "out+err>"
+    "o>>"   "out>>"
+    "e>>"   "err>>"
+    "e+o>>" "err+out>>"
+    "o+e>>" "out+err>>"
+    "o>|"   "out>|"
+    "e>|"   "err>|"
+    "e+o>|" "err+out>|"
+    "o+e>|" "out+err>|"
 ] @operator
 
 ;;; ---

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -186,7 +186,6 @@ file_path: (val_string) @variable.parameter
     "e>>"   "err>>"
     "e+o>>" "err+out>>"
     "o+e>>" "out+err>>"
-    "o>|"   "out>|"
     "e>|"   "err>|"
     "e+o>|" "err+out>|"
     "o+e>|" "out+err>|"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -19372,10 +19372,14 @@
     "_unquoted_naive": {
       "type": "TOKEN",
       "content": {
-        "type": "REPEAT1",
+        "type": "PREC",
+        "value": -1,
         "content": {
-          "type": "PATTERN",
-          "value": "[^\\s\\r\\n\\t\\|();{}]"
+          "type": "REPEAT1",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^\\s\\r\\n\\t\\|();{}]"
+          }
         }
       }
     },

--- a/test/corpus/pipe/redirection.nu
+++ b/test/corpus/pipe/redirection.nu
@@ -3,7 +3,7 @@ redir-001-command-redirection
 =====
 
 echo this o> /dev/null
-echo this e>> foo
+echo this e>> $foo
 echo this e+o>> ./foo
 echo this err+out> 32
 
@@ -23,7 +23,8 @@ echo this err+out> 32
         (cmd_identifier)
         (val_string)
         (redirection
-          (val_string)))))
+          (val_variable
+            (identifier))))))
   (pipeline
     (pipe_element
       (command


### PR DESCRIPTION
```scheme
[
    "o>>"   "out>>"
    "e>>"   "err>>"
    "e+o>>" "err+out>>"
    "o+e>>" "out+err>>"
    "o>|"   "out>|"
    "e>|"   "err>|"
    "e+o>|" "err+out>|"
    "o+e>|" "out+err>|"
] @operator

```

Missing redirection operators added to `highlights.scm`.