### PR TITLE
fix: comma in `_match_pattern_record` and `_match_pattern_list`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -38,8 +38,8 @@ module.exports = grammar({
     [$._block_body, $.val_closure],
     [$._expression_parenthesized, $._expr_binary_expression_parenthesized],
     [$._match_pattern_list, $.val_list],
+    [$._match_pattern_record, $._value],
     [$._match_pattern_record, $.val_record],
-    [$._match_pattern_record_variable, $._value],
     [$._match_pattern_value, $._value],
     [$._parenthesized_body],
     [$.block, $.val_closure],
@@ -482,15 +482,15 @@ module.exports = grammar({
       seq(
         BRACK().open_brack,
         repeat(
-          field(
-            "item",
-            seq(
+          seq(
+            field(
+              "entry",
               choice(
                 $._match_pattern_expression,
                 alias($._unquoted_in_list, $.val_string),
               ),
-              optional(PUNC().comma),
             ),
+            optional(PUNC().comma),
           ),
         ),
         optional(
@@ -515,17 +515,14 @@ module.exports = grammar({
       seq(
         BRACK().open_brace,
         repeat(
-          field(
-            "entry",
-            choice($.record_entry, $._match_pattern_record_variable),
+          seq(
+            field("entry", choice($.record_entry, $.val_variable)),
+            optional(PUNC().comma),
           ),
         ),
         BRACK().close_brace,
         optional($.cell_path),
       ),
-
-    _match_pattern_record_variable: ($) =>
-      seq($.val_variable, optional(PUNC().comma)),
 
     ctrl_try: _ctrl_try_rule(false),
     ctrl_try_parenthesized: _ctrl_try_rule(true),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4218,12 +4218,12 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "FIELD",
-            "name": "item",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "entry",
+                "content": {
                   "type": "CHOICE",
                   "members": [
                     {
@@ -4240,21 +4240,21 @@
                       "value": "val_string"
                     }
                   ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           }
         },
         {
@@ -4328,21 +4328,38 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "FIELD",
-            "name": "entry",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "record_entry"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_match_pattern_record_variable"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "entry",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "record_entry"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "val_variable"
+                    }
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           }
         },
         {
@@ -4355,27 +4372,6 @@
             {
               "type": "SYMBOL",
               "name": "cell_path"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_match_pattern_record_variable": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "val_variable"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
             },
             {
               "type": "BLANK"
@@ -20255,11 +20251,11 @@
     ],
     [
       "_match_pattern_record",
-      "val_record"
+      "_value"
     ],
     [
-      "_match_pattern_record_variable",
-      "_value"
+      "_match_pattern_record",
+      "val_record"
     ],
     [
       "_match_pattern_value",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4608,14 +4608,10 @@
     "type": "val_list",
     "named": true,
     "fields": {
-      "item": {
+      "entry": {
         "multiple": true,
         "required": false,
         "types": [
-          {
-            "type": ",",
-            "named": false
-          },
           {
             "type": "expr_parenthesized",
             "named": true
@@ -4782,10 +4778,6 @@
         "multiple": true,
         "required": false,
         "types": [
-          {
-            "type": ",",
-            "named": false
-          },
           {
             "type": "record_entry",
             "named": true

--- a/test/corpus/ctrl/match.nu
+++ b/test/corpus/ctrl/match.nu
@@ -283,6 +283,7 @@ match $x {
   {$y} => {}
   {$foo, $bar} => {}
   {$a, b: c} => {}
+  {a: b, b: c} => {}
 }
 
 -----
@@ -312,6 +313,16 @@ match $x {
             (val_record
               (val_variable
                 (identifier))
+              (record_entry
+                (identifier)
+                (val_string))))
+          (block))
+        (match_arm
+          (match_pattern
+            (val_record
+              (record_entry
+                (identifier)
+                (val_string))
               (record_entry
                 (identifier)
                 (val_string))))


### PR DESCRIPTION
This PR fixes parsing error caused by comma in `_match_pattern_record`:

<img width="551" alt="image" src="https://github.com/user-attachments/assets/56d5efed-b766-44a0-80d6-5dba9a3a7d65" />

as well as the extra item of anonymous comma in `_match_pattern_list`:

<img width="552" alt="image" src="https://github.com/user-attachments/assets/ebf442ea-20fe-4077-8071-5b99f7863ae4" />

also renamed `item` into `entry` to align with `list_body`