### PR TITLE
fix: allow `val_interpolated` as key in `record_entry`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1146,6 +1146,7 @@ module.exports = grammar({
               seq(alias($.cmd_identifier, $.identifier), repeat($._separator)),
               alias($._record_key, $.identifier),
               $.val_string,
+              $.val_interpolated,
               $.val_number,
               $.val_variable,
               $.expr_parenthesized,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -13864,6 +13864,10 @@
                   },
                   {
                     "type": "SYMBOL",
+                    "name": "val_interpolated"
+                  },
+                  {
+                    "type": "SYMBOL",
                     "name": "val_number"
                   },
                   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3744,6 +3744,10 @@
             "named": true
           },
           {
+            "type": "val_interpolated",
+            "named": true
+          },
+          {
             "type": "val_number",
             "named": true
           },

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -489,3 +489,34 @@ record-015-separated-colon-vs-closure
           (record_entry
             (identifier)
             (val_number)))))))
+
+=====
+record-016-interpolated-key
+=====
+
+{
+  $"(1)": foo
+  $'(1)': bar
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_record
+        (record_body
+          entry: (record_entry
+            key: (val_interpolated
+              expr: (expr_interpolated
+                (pipeline
+                  (pipe_element
+                    (val_number)))))
+            value: (val_string))
+          entry: (record_entry
+            key: (val_interpolated
+              expr: (expr_interpolated
+                (pipeline
+                  (pipe_element
+                    (val_number)))))
+            value: (val_string)))))))


### PR DESCRIPTION
This PR fixes the following parsing error.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/bfca903a-6db0-4e83-b288-0c5a93615994" />
