### PR TITLE
feat!: attributes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -138,7 +138,8 @@ module.exports = grammar({
       token.immediate(/[0-9\p{XID_Start}][0-9\p{XID_Continue}_-]*/),
     attribute: ($) =>
       seq(
-        field("type", seq(PUNC().at, $.attribute_identifier)),
+        PUNC().at,
+        field("type", $.attribute_identifier),
         repeat(seq($._space, optional($._cmd_arg))),
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -131,10 +131,21 @@ module.exports = grammar({
     _pipe_separator: ($) =>
       repeat1(seq(repeat($._newline), choice(PUNC().pipe, ...REDIR_PIPE()))),
 
-    /// Top Level Items
+    /// Attributes
+    attribute_list: ($) =>
+      repeat1(seq($.attribute, choice(PUNC().semicolon, $._newline))),
+    attribute_identifier: (_$) =>
+      token.immediate(/[0-9\p{XID_Start}][0-9\p{XID_Continue}_-]*/),
+    attribute: ($) =>
+      seq(
+        field("type", seq(PUNC().at, $.attribute_identifier)),
+        repeat(seq($._space, optional($._cmd_arg))),
+      ),
 
+    /// Top Level Items
     decl_def: ($) =>
       seq(
+        optional($.attribute_list),
         optional(MODIFIER().visibility),
         KEYWORD().def,
         repeat($.long_flag),

--- a/queries/nu/folds.scm
+++ b/queries/nu/folds.scm
@@ -1,0 +1,10 @@
+[
+  (attribute_list)
+  (block)
+  (command_list)
+  (parameter_bracks)
+  (record_body)
+  (val_list)
+  (val_table)
+  (val_closure)
+] @fold

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -151,6 +151,7 @@ file_path: (val_string) @variable.parameter
 (param_type [":"] @punctuation.special)
 (param_value ["="] @punctuation.special)
 (param_cmd ["@"] @punctuation.special)
+(attribute ["@"] @punctuation.special)
 (param_opt ["?"] @punctuation.special)
 (returns "->" @punctuation.special)
 

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -180,6 +180,7 @@ key: (identifier) @property
 
 (param_long_flag (long_flag_identifier) @attribute)
 (param_short_flag (param_short_flag_identifier) @attribute)
+(attribute (attribute_identifier) @attribute)
 
 (short_flag (short_flag_identifier) @attribute)
 (long_flag_identifier) @attribute

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2086,20 +2086,15 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
           "type": "FIELD",
           "name": "type",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "@"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "attribute_identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "attribute_identifier"
           }
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2050,9 +2050,99 @@
         ]
       }
     },
+    "attribute_list": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "attribute"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ";"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "attribute_identifier": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[0-9\\p{XID_Start}][0-9\\p{XID_Continue}_-]*"
+      }
+    },
+    "attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "@"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute_identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_space"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_cmd_arg"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
     "decl_def": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
         {
           "type": "CHOICE",
           "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -192,13 +192,9 @@
         ]
       },
       "type": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": "@",
-            "named": false
-          },
           {
             "type": "attribute_identifier",
             "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -66,6 +66,163 @@
     }
   },
   {
+    "type": "attribute",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_binary",
+            "named": true
+          },
+          {
+            "type": "val_bool",
+            "named": true
+          },
+          {
+            "type": "val_closure",
+            "named": true
+          },
+          {
+            "type": "val_date",
+            "named": true
+          },
+          {
+            "type": "val_duration",
+            "named": true
+          },
+          {
+            "type": "val_filesize",
+            "named": true
+          },
+          {
+            "type": "val_interpolated",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_nothing",
+            "named": true
+          },
+          {
+            "type": "val_number",
+            "named": true
+          },
+          {
+            "type": "val_range",
+            "named": true
+          },
+          {
+            "type": "val_record",
+            "named": true
+          },
+          {
+            "type": "val_string",
+            "named": true
+          },
+          {
+            "type": "val_table",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
+      "arg_spread": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
+            "type": "val_list",
+            "named": true
+          },
+          {
+            "type": "val_variable",
+            "named": true
+          }
+        ]
+      },
+      "arg_str": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "val_string",
+            "named": true
+          }
+        ]
+      },
+      "flag": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "long_flag",
+            "named": true
+          },
+          {
+            "type": "short_flag",
+            "named": true
+          }
+        ]
+      },
+      "redir": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "redirection",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "@",
+            "named": false
+          },
+          {
+            "type": "attribute_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "attribute_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "block",
     "named": true,
     "fields": {},
@@ -1322,6 +1479,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
         {
           "type": "long_flag",
           "named": true
@@ -5671,6 +5832,10 @@
   {
     "type": "as",
     "named": false
+  },
+  {
+    "type": "attribute_identifier",
+    "named": true
   },
   {
     "type": "binary",

--- a/test/corpus/decl/attribute.nu
+++ b/test/corpus/decl/attribute.nu
@@ -1,0 +1,149 @@
+=====
+attr-001-smoke-test
+=====
+
+@test
+def test [] {}
+@test; def test [] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (attribute_list
+      (attribute
+        type: (attribute_identifier)))
+    unquoted_name: (cmd_identifier)
+    parameters: (parameter_bracks)
+    body: (block))
+  (decl_def
+    (attribute_list
+      (attribute
+        type: (attribute_identifier)))
+    unquoted_name: (cmd_identifier)
+    parameters: (parameter_bracks)
+    body: (block)))
+
+=====
+attr-002-examples
+=====
+
+@example "adding some dummy paths to an empty PATH" {
+    with-env { PATH: [] } {
+        path add "returned" --ret
+    }
+} --result [returned]
+@example "adding paths based on the operating system" {
+    path add {linux: "foo"}
+}
+export def --env "path add" [
+    --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
+    --append (-a)  # append to $env.PATH instead of prepending to.
+] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (attribute_list
+      (attribute
+        type: (attribute_identifier)
+        arg: (val_string)
+        arg: (val_closure
+          (pipeline
+            (pipe_element
+              (command
+                head: (cmd_identifier)
+                arg: (val_record
+                  (record_body
+                    entry: (record_entry
+                      key: (identifier)
+                      value: (val_list))))
+                arg: (val_closure
+                  (pipeline
+                    (pipe_element
+                      (command
+                        head: (cmd_identifier)
+                        arg_str: (val_string)
+                        arg: (val_string)
+                        flag: (long_flag
+                          name: (long_flag_identifier))))))))))
+        flag: (long_flag
+          name: (long_flag_identifier))
+        arg: (val_list
+          (list_body
+            entry: (val_entry
+              item: (val_string)))))
+      (attribute
+        type: (attribute_identifier)
+        arg: (val_string)
+        arg: (val_closure
+          (pipeline
+            (pipe_element
+              (command
+                head: (cmd_identifier)
+                arg_str: (val_string)
+                arg: (val_record
+                  (record_body
+                    entry: (record_entry
+                      key: (identifier)
+                      value: (val_string))))))))))
+    (long_flag
+      name: (long_flag_identifier))
+    quoted_name: (val_string)
+    parameters: (parameter_bracks
+      (parameter
+        param_long_flag: (param_long_flag
+          (long_flag_identifier))
+        flag_capsule: (flag_capsule
+          (param_short_flag
+            name: (param_short_flag_identifier)))
+        (comment))
+      (parameter
+        param_long_flag: (param_long_flag
+          (long_flag_identifier))
+        flag_capsule: (flag_capsule
+          (param_short_flag
+            name: (param_short_flag_identifier)))
+        (comment)))
+    body: (block)))
+
+=====
+attr-003-mixed
+=====
+
+@search-terms multiply times
+@example "random" {2 | double}; @test; def double []: [number -> number] { $in * 2 }
+
+-----
+
+(nu_script
+  (decl_def
+    (attribute_list
+      (attribute
+        type: (attribute_identifier)
+        arg_str: (val_string)
+        arg_str: (val_string))
+      (attribute
+        type: (attribute_identifier)
+        arg: (val_string)
+        arg: (val_closure
+          (pipeline
+            (pipe_element
+              (val_number))
+            (pipe_element
+              (command
+                head: (cmd_identifier))))))
+      (attribute
+        type: (attribute_identifier)))
+    unquoted_name: (cmd_identifier)
+    parameters: (parameter_bracks)
+    return_type: (returns
+      type: (flat_type)
+      type: (flat_type))
+    body: (block
+      (pipeline
+        (pipe_element
+          (expr_binary
+            lhs: (val_variable)
+            rhs: (val_number)))))))


### PR DESCRIPTION
Adds support of https://github.com/nushell/nushell/pull/14906#issuecomment-2652223446 @Bahex

<img width="419" alt="image" src="https://github.com/user-attachments/assets/656253f4-d3df-4739-8c9c-9cebba3028bb" />


This is a general implementation for all kinds of attributes,
We can discuss whether we need more detailed ones for specific attribute like `example`

And this is a breaking change since it modifies `highlights.scm` and adds a new `folds.scm` file,
I'll update nvim-treesitter latter when we nail down the details.