### PR TITLE
refactor: states count reduction for `val_table`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -43,7 +43,7 @@ module.exports = grammar({
     [$.ctrl_if_parenthesized],
     [$.ctrl_try_parenthesized],
     [$.expr_binary_parenthesized],
-    [$.list_body, $.val_table],
+    [$.list_body, $._table_head],
     [$.parameter, $.param_type, $.param_value],
     [$.pipeline],
     [$.pipeline_parenthesized],
@@ -54,7 +54,7 @@ module.exports = grammar({
 
     nu_script: ($) => seq(optional($.shebang), optional($._block_body)),
 
-    shebang: (_$) => seq(repeat(_$._newline), "#!", /.*\r?\n?/),
+    shebang: ($) => seq(repeat($._newline), "#!", /.*\r?\n?/),
 
     ...block_body_rules(),
 
@@ -1180,12 +1180,17 @@ module.exports = grammar({
     _table_head_separator: (_$) =>
       token(prec(PREC().higher, seq(/\s*/, PUNC().semicolon))),
 
-    val_table: ($) =>
+    _table_head: ($) =>
       seq(
-        BRACK().open_brack,
         repeat($._newline),
         field("head", $.val_list),
         alias($._table_head_separator, PUNC().semicolon),
+      ),
+
+    val_table: ($) =>
+      seq(
+        BRACK().open_brack,
+        $._table_head,
         optional(
           general_body_rules("row", $.val_list, $._entry_separator, $._newline),
         ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -14796,13 +14796,9 @@
         }
       }
     },
-    "val_table": {
+    "_table_head": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
         {
           "type": "REPEAT",
           "content": {
@@ -14826,6 +14822,19 @@
           },
           "named": false,
           "value": ";"
+        }
+      ]
+    },
+    "val_table": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_table_head"
         },
         {
           "type": "CHOICE",
@@ -16600,7 +16609,7 @@
     ],
     [
       "list_body",
-      "val_table"
+      "_table_head"
     ],
     [
       "parameter",


### PR DESCRIPTION
PoC for #185

## States Count

reduced to

> 16:#define STATE_COUNT 7389
> 17:#define LARGE_STATE_COUNT 1669

from

> 16:#define STATE_COUNT 7954
> 17:#define LARGE_STATE_COUNT 1749

## Per Rule After

|rule name | count |
|----------|-------|
|val_range                                | 817|
|expr_binary_parenthesized                | 614|
|shebang_repeat1                          | 537|
|val_table                                | 534|
|_immediate_decimal                       | 474|
|_val_range                               | 374|
|_val_number_decimal                      | 362|
|collection_type                          | 330|
|_val_range_with_end                      | 266|
|expr_binary                              | 210|
|_multiple_types_repeat1                  | 200|
|collection_type_repeat1                  | 189|
|val_closure                              | 183|
|val_table_repeat1                        | 183|
|unquoted                                 | 174|
|_unquoted_anonymous_prefix               | 166|
|_unquoted_with_expr                      | 165|
|ctrl_if_parenthesized                    | 158|
|_str_double_quotes                       | 156|
