### PR TITLE
refactor: unquoted_pattern_repeat & flag_equals_value

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,4 @@
+const f = 1;
 /// <reference types="tree-sitter-cli/dsl" />
 // @ts-check
 module.exports = grammar({
@@ -1289,13 +1290,13 @@ module.exports = grammar({
 
     _flag_value: ($) => choice($._value, alias($.unquoted, $.val_string)),
 
+    _flag_equals_value: ($) => seq(token.immediate(PUNC().eq), field("value", $._flag_value)),
+
     short_flag: ($) =>
       seq(
         OPR().minus,
         optional(field("name", $.short_flag_identifier)),
-        optional(
-          seq(token.immediate(PUNC().eq), field("value", $._flag_value)),
-        ),
+        optional($._flag_equals_value),
       ),
 
     short_flag_identifier: (_$) => token.immediate(/[\p{XID_Continue}?@!%_-]+/),
@@ -1304,9 +1305,7 @@ module.exports = grammar({
       seq(
         OPR().long_flag,
         optional(field("name", $.long_flag_identifier)),
-        optional(
-          seq(token.immediate(PUNC().eq), field("value", $._flag_value)),
-        ),
+        optional($._flag_equals_value),
       ),
 
     _unquoted_naive: (_$) => token(prec(PREC().low, repeat1(none_of("{}")))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15830,6 +15830,26 @@
         }
       ]
     },
+    "_flag_equals_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "="
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_flag_value"
+          }
+        }
+      ]
+    },
     "short_flag": {
       "type": "SEQ",
       "members": [
@@ -15857,24 +15877,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "="
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_flag_value"
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_flag_equals_value"
             },
             {
               "type": "BLANK"
@@ -15917,24 +15921,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "="
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_flag_value"
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_flag_equals_value"
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15931,6 +15931,296 @@
         }
       ]
     },
+    "_unquoted_pattern": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -69,
+        "content": {
+          "type": "REPEAT1",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+          }
+        }
+      }
+    },
+    "_unquoted_pattern_in_list": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -69,
+        "content": {
+          "type": "REPEAT1",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+          }
+        }
+      }
+    },
+    "_unquoted_pattern_in_record": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -69,
+        "content": {
+          "type": "REPEAT1",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+          }
+        }
+      }
+    },
+    "_unquoted_in_list": {
+      "type": "PREC_LEFT",
+      "value": -69,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": -69,
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$,]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_val_range"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_val_number_decimal"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[nN][aA][nN]"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_pattern_in_list"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ".."
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "..="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "..<"
+                  }
+                ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": -69,
+                  "content": {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_anonymous_prefix"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_pattern_in_list"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_unquoted_in_record": {
+      "type": "PREC_LEFT",
+      "value": -69,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": -69,
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$:,]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_val_range"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_val_number_decimal"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[nN][aA][nN]"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_pattern_in_record"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ".."
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "..="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "..<"
+                  }
+                ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": -69,
+                  "content": {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_anonymous_prefix"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_unquoted_pattern_in_record"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "_unquoted_naive": {
       "type": "TOKEN",
       "content": {
@@ -16009,21 +16299,8 @@
                 ]
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -69,
-                  "content": {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
-                      }
-                    }
-                  }
-                }
+                "type": "SYMBOL",
+                "name": "_unquoted_pattern"
               }
             ]
           },
@@ -16074,309 +16351,8 @@
                 "name": "_unquoted_anonymous_prefix"
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "REPEAT1",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_unquoted_in_list": {
-      "type": "PREC_LEFT",
-      "value": -69,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "TOKEN",
-            "content": {
-              "type": "PREC",
-              "value": -69,
-              "content": {
-                "type": "TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$,]"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_val_range"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_val_number_decimal"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[nN][aA][nN]"
-                  }
-                ]
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -69,
-                  "content": {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ".."
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..<"
-                  }
-                ]
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -69,
-                  "content": {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
                 "type": "SYMBOL",
-                "name": "_unquoted_anonymous_prefix"
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "REPEAT1",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_unquoted_in_record": {
-      "type": "PREC_LEFT",
-      "value": -69,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "TOKEN",
-            "content": {
-              "type": "PREC",
-              "value": -69,
-              "content": {
-                "type": "TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$:,]"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_val_range"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_val_number_decimal"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[iI][nN][fF]([iI][nN][iI][tT][yY])?"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "-[iI][nN][fF]([iI][nN][iI][tT][yY])?"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[nN][aA][nN]"
-                  }
-                ]
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -69,
-                  "content": {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ".."
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..="
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..<"
-                  }
-                ]
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -69,
-                  "content": {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_unquoted_anonymous_prefix"
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "REPEAT1",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                    }
-                  }
-                }
+                "name": "_unquoted_pattern"
               }
             ]
           }
@@ -16671,70 +16647,6 @@
     "_unquoted_anonymous_prefix": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "STRING",
-          "value": "err>"
-        },
-        {
-          "type": "STRING",
-          "value": "out>"
-        },
-        {
-          "type": "STRING",
-          "value": "e>"
-        },
-        {
-          "type": "STRING",
-          "value": "o>"
-        },
-        {
-          "type": "STRING",
-          "value": "err+out>"
-        },
-        {
-          "type": "STRING",
-          "value": "out+err>"
-        },
-        {
-          "type": "STRING",
-          "value": "o+e>"
-        },
-        {
-          "type": "STRING",
-          "value": "e+o>"
-        },
-        {
-          "type": "STRING",
-          "value": "err>>"
-        },
-        {
-          "type": "STRING",
-          "value": "out>>"
-        },
-        {
-          "type": "STRING",
-          "value": "e>>"
-        },
-        {
-          "type": "STRING",
-          "value": "o>>"
-        },
-        {
-          "type": "STRING",
-          "value": "err+out>>"
-        },
-        {
-          "type": "STRING",
-          "value": "out+err>>"
-        },
-        {
-          "type": "STRING",
-          "value": "o+e>>"
-        },
-        {
-          "type": "STRING",
-          "value": "e+o>>"
-        },
         {
           "type": "STRING",
           "value": "null"

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -558,7 +558,6 @@ echo infms
 echo nankb
 echo true-foo
 echo null-foo
-echo e>foo
 echo 1ms-foo
 echo 1mb-foo
 echo .1foo
@@ -570,11 +569,6 @@ echo 1991-02-02foo
 ------
 
 (nu_script
-  (pipeline
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_string))))
   (pipeline
     (pipe_element
       (command
@@ -801,7 +795,6 @@ echo .1ms()
 echo .1mb()
 echo 2024-01-01()
 echo .1()
-echo e>()
 echo ..=1()
 echo ..1..<1()
 echo .1..=1()
@@ -834,12 +827,6 @@ echo 1...()
             (pipeline
               (pipe_element
                 (val_string))))
-          (expr_parenthesized)))))
-  (pipeline
-    (pipe_element
-      (command
-        (cmd_identifier)
-        (val_string
           (expr_parenthesized)))))
   (pipeline
     (pipe_element


### PR DESCRIPTION
#185 

> 16:#define STATE_COUNT 6432
> 17:#define LARGE_STATE_COUNT 1254

The case statement count in `ts_lex` reduced from 4040 to 3290, while the total state count doesn't change much.
Time to verify the statement that wasm compilation time is mainly determined by `ts_lex` case count.

Sadly, `tree-sitter build -w` keeps pulling the docker image of wrong arch on my arm64 machine.
Have to rely on your test number, @fdncred. 

One more failing case compared to previous ver:

```nushell
echo e>foo
echo err>>foo
```

But I checked `nu_scripts`, seems nobody actually writes crazy stuff like that