### PR TITLE
fix: hide-env with more than one variable

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -614,11 +614,7 @@ module.exports = grammar({
       ),
 
     hide_env: ($) =>
-      seq(
-        KEYWORD().hide_env,
-        repeat($._flag),
-        field("variable", $._variable_name),
-      ),
+      seq(KEYWORD().hide_env, repeat($._flag), repeat1($._variable_name)),
 
     _stmt_overlay: ($) =>
       choice($.overlay_hide, $.overlay_list, $.overlay_new, $.overlay_use),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4970,8 +4970,7 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "variable",
+          "type": "REPEAT1",
           "content": {
             "type": "SYMBOL",
             "name": "_variable_name"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2547,7 +2547,7 @@
     "named": true,
     "fields": {
       "dollar_name": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {
@@ -2557,25 +2557,11 @@
         ]
       },
       "var_name": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {
             "type": "identifier",
-            "named": true
-          }
-        ]
-      },
-      "variable": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "val_variable",
             "named": true
           }
         ]

--- a/test/corpus/stmt/hide.nu
+++ b/test/corpus/stmt/hide.nu
@@ -64,3 +64,22 @@ hide-env --ignore-errors FOO;
     (long_flag
       (long_flag_identifier))
     (identifier)))
+
+=====
+hide-env-004-multiple-names
+=====
+
+hide-env -i FOO BAR;
+hide-env FOO BAR;
+
+-----
+
+(nu_script
+  (hide_env
+    (short_flag
+      name: (short_flag_identifier))
+    var_name: (identifier)
+    var_name: (identifier))
+  (hide_env
+    var_name: (identifier)
+    var_name: (identifier)))


### PR DESCRIPTION
Fixes parsing error of

```nushell
hide-env FOO BAR
```