### PR TITLE
fix: id in collection_type should allow hyphen

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -287,7 +287,13 @@ module.exports = grammar({
       ),
     _collection_entry: ($) =>
       seq(
-        field("key", choice($.identifier, alias($.val_string, $.identifier))),
+        field(
+          "key",
+          choice(
+            alias($._unquoted_in_record, $.identifier),
+            alias($.val_string, $.identifier),
+          ),
+        ),
         optional($._collection_annotation),
       ),
     _collection_body: ($) =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3114,8 +3114,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_unquoted_in_record"
+                },
+                "named": true,
+                "value": "identifier"
               },
               {
                 "type": "ALIAS",

--- a/test/corpus/stmt/let.nu
+++ b/test/corpus/stmt/let.nu
@@ -69,21 +69,21 @@ let x: string = 'tree-sitter'
 let-005-with-complex-type
 =====
 
-let x: record<name: string> = { name: 'tree-sitter' }
+let x: record<foo-bar: string> = { foo-bar: 'tree-sitter' }
 
 -----
 
 (nu_script
   (stmt_let
-    (identifier)
-    (param_type
-      (collection_type
-        (identifier)
-        (flat_type)))
-    (pipeline
+    var_name: (identifier)
+    type: (param_type
+      type: (collection_type
+        key: (identifier)
+        type: (flat_type)))
+    value: (pipeline
       (pipe_element
         (val_record
           (record_body
-            (record_entry
-              (identifier)
-              (val_string))))))))
+            entry: (record_entry
+              key: (identifier)
+              value: (val_string))))))))


### PR DESCRIPTION
Fixes parsing error in this:

```nushell
let x: record<foo-bar: string> = { foo-bar: 'tree-sitter' }
```