### PR TITLE
fix: ctrl_do with expr_paren

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -412,7 +412,7 @@ module.exports = grammar({
       seq(
         KEYWORD().do,
         repeat($._flag),
-        choice($._blosure, $.val_variable),
+        choice($._blosure, $.val_variable, $.expr_parenthesized),
         repeat($._do_expression),
       ),
 
@@ -421,7 +421,7 @@ module.exports = grammar({
         KEYWORD().do,
         repeat($._flags_parenthesized),
         repeat1($._separator),
-        choice($._blosure, $.val_variable),
+        choice($._blosure, $.val_variable, $.expr_parenthesized),
         repeat(seq(optional($._repeat_newline), $._do_expression)),
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3700,6 +3700,10 @@
             {
               "type": "SYMBOL",
               "name": "val_variable"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expr_parenthesized"
             }
           ]
         },
@@ -3743,6 +3747,10 @@
             {
               "type": "SYMBOL",
               "name": "val_variable"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expr_parenthesized"
             }
           ]
         },

--- a/test/corpus/ctrl/do.nu
+++ b/test/corpus/ctrl/do.nu
@@ -203,3 +203,25 @@ do-005-parenthesized-no-arguments
             (ctrl_do
               (block))))
         (comment)))))
+
+=====
+do-006-closure-in-parenthesis
+=====
+
+do ({echo hello})
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (ctrl_do
+        (expr_parenthesized
+          (pipeline
+            (pipe_element
+              (val_closure
+                (pipeline
+                  (pipe_element
+                    (command
+                      (cmd_identifier)
+                      (val_string))))))))))))


### PR DESCRIPTION
Fixes parsing error caused by:

```nushell
do ({echo hello})
```