### PR TITLE
fix: empty closure

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -33,11 +33,12 @@ module.exports = grammar({
     [$._expression_parenthesized, $._expr_binary_expression_parenthesized],
     [$._match_pattern_list, $.val_list],
     [$._match_pattern_record, $._value],
+    [$._match_pattern_record, $.val_record, $.val_closure],
     [$._match_pattern_record, $.val_record],
     [$._match_pattern_value, $._value],
     [$._parenthesized_body],
     [$.block, $.val_closure],
-    [$.block, $.val_record],
+    [$.block, $.val_record, $.val_closure],
     [$.command, $.record_entry],
     [$.ctrl_do_parenthesized],
     [$.ctrl_if_parenthesized],
@@ -48,6 +49,7 @@ module.exports = grammar({
     [$.parameter, $.param_type, $.param_value],
     [$.pipeline],
     [$.pipeline_parenthesized],
+    [$.val_record, $.val_closure],
   ],
 
   rules: {
@@ -677,7 +679,7 @@ module.exports = grammar({
     block: ($) =>
       seq(BRACK().open_brace, optional($._block_body), BRACK().close_brace),
 
-    _blosure: ($) => choice(prec.dynamic(10, $.block), $.val_closure),
+    _blosure: ($) => choice($.block, $.val_closure),
 
     // the where command has a unique argument pattern that breaks the
     // general command parsing, so we handle it separately
@@ -1218,7 +1220,7 @@ module.exports = grammar({
         BRACK().open_brace,
         optional($._repeat_newline),
         optional(field("parameters", $.parameter_pipes)),
-        $._block_body,
+        optional($._block_body),
         BRACK().close_brace,
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5345,12 +5345,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC_DYNAMIC",
-          "value": 10,
-          "content": {
-            "type": "SYMBOL",
-            "name": "block"
-          }
+          "type": "SYMBOL",
+          "name": "block"
         },
         {
           "type": "SYMBOL",
@@ -16025,8 +16021,16 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_block_body"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -17552,6 +17556,11 @@
     ],
     [
       "_match_pattern_record",
+      "val_record",
+      "val_closure"
+    ],
+    [
+      "_match_pattern_record",
       "val_record"
     ],
     [
@@ -17567,7 +17576,8 @@
     ],
     [
       "block",
-      "val_record"
+      "val_record",
+      "val_closure"
     ],
     [
       "command",
@@ -17602,6 +17612,10 @@
     ],
     [
       "pipeline_parenthesized"
+    ],
+    [
+      "val_record",
+      "val_closure"
     ]
   ],
   "precedences": [],

--- a/test/corpus/expr/closure.nu
+++ b/test/corpus/expr/closure.nu
@@ -261,3 +261,26 @@ closure-010-dummy-closure
   (pipeline
     (pipe_element
       (val_closure))))
+
+=====
+closure-011-empty-closure
+=====
+
+{|| }
+{
+||
+# comment
+}
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (val_closure
+        parameters: (parameter_pipes))))
+  (pipeline
+    (pipe_element
+      (val_closure
+        parameters: (parameter_pipes)
+        (comment)))))


### PR DESCRIPTION
Fixes

```nushell
{||}
```

Seems to me that rules for `val_closure`/`val_record`/`block` are delicately balanced in current parser.
That's not very healthy for maintenance. 

Each time I tried to optimize those rules, I ended up breaking some test cases.