### PR TITLE
fix: allow flag equals immediate subexpressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1291,7 +1291,12 @@ module.exports = grammar({
 
     _flags_parenthesized: ($) => seq(repeat1($._separator), $._flag),
 
-    _flag_value: ($) => choice($._value, alias($.unquoted, $.val_string)),
+    _flag_value: ($) =>
+      choice(
+        $._value,
+        alias($.unquoted, $.val_string),
+        alias($._expr_parenthesized_immediate, $.expr_parenthesized),
+      ),
 
     _flag_equals_value: ($) =>
       seq(token.immediate(PUNC().eq), field("value", $._flag_value)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -16625,6 +16625,15 @@
           },
           "named": true,
           "value": "val_string"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr_parenthesized_immediate"
+          },
+          "named": true,
+          "value": "expr_parenthesized"
         }
       ]
     },
@@ -17644,5 +17653,6 @@
     "_stringish",
     "_terminator"
   ],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2754,6 +2754,10 @@
         "required": false,
         "types": [
           {
+            "type": "expr_parenthesized",
+            "named": true
+          },
+          {
             "type": "val_binary",
             "named": true
           },
@@ -4151,6 +4155,10 @@
         "multiple": false,
         "required": false,
         "types": [
+          {
+            "type": "expr_parenthesized",
+            "named": true
+          },
           {
             "type": "val_binary",
             "named": true

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,12 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +32,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +86,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +106,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +122,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +142,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -485,7 +485,7 @@ cmd-018-pipe-external
 cmd-019-flags-with-values
 =====
 
-bla --weird-that=this --behaved-differently=than-this --level=2
+bla --weird-that=this --behaved-differently=than-this --level=2 --expr=(1 + 1)
 ^dummy - -- -color=true
 
 -----
@@ -503,7 +503,15 @@ bla --weird-that=this --behaved-differently=than-this --level=2
           value: (val_string))
         flag: (long_flag
           name: (long_flag_identifier)
-          value: (val_number)))))
+          value: (val_number))
+        flag: (long_flag
+          name: (long_flag_identifier)
+          value: (expr_parenthesized
+            (pipeline
+              (pipe_element
+                (expr_binary
+                  lhs: (val_number)
+                  rhs: (val_number)))))))))
   (pipeline
     (pipe_element
       (command


### PR DESCRIPTION
Fixes the error caused by such syntax: `foo --bar=(baz)`.