### PR TITLE
fix: new syntax in ver.105

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -260,6 +260,10 @@ key: (identifier) @property
     ["," ":"] @punctuation.special
     ">" @punctuation.bracket
 )
+(composite_type
+    "oneof" @type.enum
+    ["<" ">"] @punctuation.bracket
+)
 
 (shebang) @keyword.directive
 (comment) @comment

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2925,6 +2925,10 @@
           {
             "type": "SYMBOL",
             "name": "flat_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "composite_type"
           }
         ]
       }
@@ -2946,6 +2950,10 @@
           {
             "type": "SYMBOL",
             "name": "flat_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "composite_type"
           }
         ]
       }
@@ -3239,32 +3247,27 @@
           ]
         },
         {
-          "type": "SEQ",
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "<"
+          }
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "STRING",
-                "value": "<"
-              }
+              "type": "SYMBOL",
+              "name": "_collection_body"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_collection_body"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ">"
+              "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": ">"
         }
       ]
     },
@@ -3276,52 +3279,117 @@
           "value": "list"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "STRING",
-                "value": "<"
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "<"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "inner",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_all_type"
+              },
+              {
+                "type": "BLANK"
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "inner",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_all_type"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "completion",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "param_cmd"
+              },
+              {
+                "type": "BLANK"
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "completion",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "param_cmd"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "STRING",
-              "value": ">"
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "_composite_argument_body": {
+      "type": "PREC",
+      "value": 20,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_newline"
             }
-          ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_all_type"
+                },
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_entry_separator"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_all_type"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_entry_separator"
+            }
+          }
+        ]
+      }
+    },
+    "composite_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "oneof"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "<"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_composite_argument_body"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
         }
       ]
     },
@@ -5919,6 +5987,10 @@
         {
           "type": "SYMBOL",
           "name": "val_bool"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "val_variable"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -370,6 +370,10 @@
             "named": true
           },
           {
+            "type": "composite_type",
+            "named": true
+          },
+          {
             "type": "flat_type",
             "named": true
           },
@@ -583,6 +587,34 @@
     "type": "comment",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "composite_type",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "collection_type",
+            "named": true
+          },
+          {
+            "type": "composite_type",
+            "named": true
+          },
+          {
+            "type": "flat_type",
+            "named": true
+          },
+          {
+            "type": "list_type",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "ctrl_do",
@@ -2706,6 +2738,10 @@
             "named": true
           },
           {
+            "type": "composite_type",
+            "named": true
+          },
+          {
             "type": "flat_type",
             "named": true
           },
@@ -2721,6 +2757,10 @@
         "types": [
           {
             "type": "collection_type",
+            "named": true
+          },
+          {
+            "type": "composite_type",
             "named": true
           },
           {
@@ -3448,6 +3488,10 @@
             "named": true
           },
           {
+            "type": "composite_type",
+            "named": true
+          },
+          {
             "type": "flat_type",
             "named": true
           },
@@ -4054,6 +4098,10 @@
         "types": [
           {
             "type": "collection_type",
+            "named": true
+          },
+          {
+            "type": "composite_type",
             "named": true
           },
           {
@@ -6213,6 +6261,10 @@
   },
   {
     "type": "one-of",
+    "named": false
+  },
+  {
+    "type": "oneof",
     "named": false
   },
   {

--- a/test/corpus/decl/def.nu
+++ b/test/corpus/decl/def.nu
@@ -1044,3 +1044,39 @@ def open-pr [
             (identifier)
             (flat_type)))))
     (block)))
+
+======
+def-035-composite-types
+======
+
+def composite-type [
+    input: oneof<
+      int
+      list<record>
+    >
+]: oneof<int, bool> -> oneof<nothing,
+oneof<int, bool>> {}
+
+-----
+
+(nu_script
+  (decl_def
+    unquoted_name: (cmd_identifier)
+    parameters: (parameter_bracks
+      (parameter
+        param_name: (identifier)
+        (param_type
+          type: (composite_type
+            type: (flat_type)
+            type: (list_type
+              type: (flat_type))))))
+    return_type: (returns
+      type: (composite_type
+        type: (flat_type)
+        type: (flat_type))
+      type: (composite_type
+        type: (flat_type)
+        type: (composite_type
+          type: (flat_type)
+          type: (flat_type))))
+    body: (block)))

--- a/test/corpus/pipe/where.nu
+++ b/test/corpus/pipe/where.nu
@@ -231,3 +231,27 @@ ls | where name not-has "e"
       (where_command
         lhs: (val_string)
         rhs: (val_string)))))
+
+=====
+where-009-variable
+=====
+
+ls | where $foo.bar and $foo.baz
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (command
+        head: (cmd_identifier)))
+    (pipe_element
+      (where_command
+        lhs: (val_variable
+          name: (identifier)
+          (cell_path
+            (path)))
+        rhs: (val_variable
+          name: (identifier)
+          (cell_path
+            (path)))))))

--- a/test/corpus/stmt/let.nu
+++ b/test/corpus/stmt/let.nu
@@ -70,6 +70,7 @@ let-005-with-complex-type
 =====
 
 let x: record<foo-bar: string> = { foo-bar: 'tree-sitter' }
+let y: oneof<int, list<record>> = 1
 
 -----
 
@@ -86,4 +87,14 @@ let x: record<foo-bar: string> = { foo-bar: 'tree-sitter' }
           (record_body
             entry: (record_entry
               key: (identifier)
-              value: (val_string))))))))
+              value: (val_string)))))))
+  (stmt_let
+    var_name: (identifier)
+    type: (param_type
+      type: (composite_type
+        type: (flat_type)
+        type: (list_type
+          type: (flat_type))))
+    value: (pipeline
+      (pipe_element
+        (val_number)))))


### PR DESCRIPTION
Adds support for the new syntaxes of nu 0.105:

1. where + variable predicate
2. oneof type constructor

cc. @Bahex, please remind me if I missed something.