### PR TITLE
feat: allow new type of bare word string interpolation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1933,27 +1933,22 @@ function _range_rule(anonymous) {
  * @param {string} type
  */
 function _unquoted_with_expr_rule(type) {
-  let excluded = '';
-  switch (type) {
-    case 'list':
-      excluded += '\\[\\],';
-      break;
-    case 'record':
-      excluded += '{}:,';
-      break;
-  }
-  const pattern_repeat = token.immediate(repeat(none_of(excluded)));
-  const pattern_repeat1 = token.immediate(repeat1(none_of(excluded)));
   return ($) => {
     let unquoted_head = $.unquoted;
+    let excluded = '';
     switch (type) {
       case 'list':
         unquoted_head = $._unquoted_in_list;
+        excluded += '\\[\\],';
         break;
       case 'record':
         unquoted_head = $._unquoted_in_record;
+        excluded += '{}:,';
         break;
     }
+    const pattern_once = token.immediate(none_of(excluded));
+    const pattern_repeat = token.immediate(repeat(none_of(excluded)));
+
     return seq(
       choice(
         seq(
@@ -1968,7 +1963,7 @@ function _unquoted_with_expr_rule(type) {
         seq(
           $.expr_parenthesized,
           choice(
-            pattern_repeat1,
+            pattern_once,
             alias($._expr_parenthesized_immediate, $.expr_parenthesized),
           ),
         ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -16998,26 +16998,20 @@
               "type": "PREC",
               "value": -69,
               "content": {
-                "type": "TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$-]"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
-                        }
-                      }
-                    ]
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$-]"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
+                    }
                   }
-                }
+                ]
               }
             }
           },
@@ -17081,13 +17075,10 @@
                   "type": "PREC",
                   "value": -69,
                   "content": {
-                    "type": "TOKEN",
+                    "type": "REPEAT",
                     "content": {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
-                      }
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`']"
                     }
                   }
                 }
@@ -17122,26 +17113,20 @@
               "type": "PREC",
               "value": -69,
               "content": {
-                "type": "TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$,]"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                        }
-                      }
-                    ]
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$,]"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
+                    }
                   }
-                }
+                ]
               }
             }
           },
@@ -17205,13 +17190,10 @@
                   "type": "PREC",
                   "value": -69,
                   "content": {
-                    "type": "TOKEN",
+                    "type": "REPEAT",
                     "content": {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
-                      }
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`',]"
                     }
                   }
                 }
@@ -17246,26 +17228,20 @@
               "type": "PREC",
               "value": -69,
               "content": {
-                "type": "TOKEN",
-                "content": {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$:,]"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                        }
-                      }
-                    ]
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`'$:,]"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
+                    }
                   }
-                }
+                ]
               }
             }
           },
@@ -17329,13 +17305,10 @@
                   "type": "PREC",
                   "value": -69,
                   "content": {
-                    "type": "TOKEN",
+                    "type": "REPEAT",
                     "content": {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
-                      }
+                      "type": "PATTERN",
+                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]{}\"`':,]"
                     }
                   }
                 }
@@ -17359,64 +17332,68 @@
       }
     },
     "_unquoted_with_expr": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_unquoted_anonymous_prefix"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_number_decimal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_range"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "unquoted"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_anonymous_prefix"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_number_decimal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_range"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "unquoted"
+                      },
+                      "named": false,
+                      "value": "_head"
+                    }
+                  ]
                 },
-                "named": false,
-                "value": "_head"
-              }
-            ]
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expr_parenthesized_immediate"
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expr_parenthesized_immediate"
+                  },
+                  "named": true,
+                  "value": "expr_parenthesized"
+                }
+              ]
             },
-            "named": true,
-            "value": "expr_parenthesized"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expr_parenthesized"
+                },
+                {
+                  "type": "CHOICE",
                   "members": [
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "TOKEN",
+                        "type": "REPEAT1",
                         "content": {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "[^\\s\\r\\n\\t\\|();]"
-                          }
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();]"
                         }
                       }
                     },
@@ -17431,87 +17408,112 @@
                     }
                   ]
                 }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();]"
+                  }
+                }
               },
               {
-                "type": "BLANK"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr_parenthesized_immediate"
+                },
+                "named": true,
+                "value": "expr_parenthesized"
               }
             ]
-          },
-          {
-            "type": "IMMEDIATE_TOKEN",
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "REPEAT",
             "content": {
-              "type": "TOKEN",
-              "content": {
-                "type": "REPEAT",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\r\\n\\t\\|();]"
-                }
-              }
+              "type": "PATTERN",
+              "value": "[^\\s\\r\\n\\t\\|();]"
             }
           }
-        ]
-      }
+        }
+      ]
     },
     "_unquoted_in_list_with_expr": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_unquoted_anonymous_prefix"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_number_decimal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_range"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_unquoted_in_list"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_anonymous_prefix"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_number_decimal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_range"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_unquoted_in_list"
+                      },
+                      "named": false,
+                      "value": "_head"
+                    }
+                  ]
                 },
-                "named": false,
-                "value": "_head"
-              }
-            ]
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expr_parenthesized_immediate"
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expr_parenthesized_immediate"
+                  },
+                  "named": true,
+                  "value": "expr_parenthesized"
+                }
+              ]
             },
-            "named": true,
-            "value": "expr_parenthesized"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expr_parenthesized"
+                },
+                {
+                  "type": "CHOICE",
                   "members": [
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "TOKEN",
+                        "type": "REPEAT1",
                         "content": {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
-                          }
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
                         }
                       }
                     },
@@ -17526,87 +17528,112 @@
                     }
                   ]
                 }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
+                  }
+                }
               },
               {
-                "type": "BLANK"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr_parenthesized_immediate"
+                },
+                "named": true,
+                "value": "expr_parenthesized"
               }
             ]
-          },
-          {
-            "type": "IMMEDIATE_TOKEN",
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "REPEAT",
             "content": {
-              "type": "TOKEN",
-              "content": {
-                "type": "REPEAT",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
-                }
-              }
+              "type": "PATTERN",
+              "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
             }
           }
-        ]
-      }
+        }
+      ]
     },
     "_unquoted_in_record_with_expr": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_unquoted_anonymous_prefix"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_number_decimal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_val_range"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_unquoted_in_record"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_unquoted_anonymous_prefix"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_number_decimal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_val_range"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_unquoted_in_record"
+                      },
+                      "named": false,
+                      "value": "_head"
+                    }
+                  ]
                 },
-                "named": false,
-                "value": "_head"
-              }
-            ]
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expr_parenthesized_immediate"
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expr_parenthesized_immediate"
+                  },
+                  "named": true,
+                  "value": "expr_parenthesized"
+                }
+              ]
             },
-            "named": true,
-            "value": "expr_parenthesized"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expr_parenthesized"
+                },
+                {
+                  "type": "CHOICE",
                   "members": [
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "TOKEN",
+                        "type": "REPEAT1",
                         "content": {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "[^\\s\\r\\n\\t\\|();{}:,]"
-                          }
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();{}:,]"
                         }
                       }
                     },
@@ -17621,27 +17648,48 @@
                     }
                   ]
                 }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\s\\r\\n\\t\\|();{}:,]"
+                  }
+                }
               },
               {
-                "type": "BLANK"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr_parenthesized_immediate"
+                },
+                "named": true,
+                "value": "expr_parenthesized"
               }
             ]
-          },
-          {
-            "type": "IMMEDIATE_TOKEN",
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "REPEAT",
             "content": {
-              "type": "TOKEN",
-              "content": {
-                "type": "REPEAT",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\s\\r\\n\\t\\|();{}:,]"
-                }
-              }
+              "type": "PATTERN",
+              "value": "[^\\s\\r\\n\\t\\|();{}:,]"
             }
           }
-        ]
-      }
+        }
+      ]
     },
     "_unquoted_anonymous_prefix": {
       "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -17390,11 +17390,8 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "REPEAT1",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();]"
-                        }
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();]"
                       }
                     },
                     {
@@ -17510,11 +17507,8 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "REPEAT1",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
-                        }
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\],]"
                       }
                     },
                     {
@@ -17630,11 +17624,8 @@
                     {
                       "type": "IMMEDIATE_TOKEN",
                       "content": {
-                        "type": "REPEAT1",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\\s\\r\\n\\t\\|();{}:,]"
-                        }
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();{}:,]"
                       }
                     },
                     {

--- a/test/corpus/expr/list.nu
+++ b/test/corpus/expr/list.nu
@@ -452,8 +452,10 @@ list-013-unquoted-with-immediate-expr-parenthesized
 [
   foo(
 'bar')baz(
-1)
+1)qux
   foo('bar')()
+  (1)(1)
+  (1)foo
   .()
   true()
   null()
@@ -476,8 +478,8 @@ list-013-unquoted-with-immediate-expr-parenthesized
     (pipe_element
       (val_list
         (list_body
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized
                 (pipeline
                   (pipe_element
@@ -487,55 +489,71 @@ list-013-unquoted-with-immediate-expr-parenthesized
                 (pipeline
                   (pipe_element
                     (val_number))))))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized
                 (pipeline
                   (pipe_element
                     (val_string
                       (string_content)))))
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))))
+          entry: (val_entry
+            item: (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))))
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized)))
-          (val_entry
-            (val_string
+          entry: (val_entry
+            item: (val_string
               (expr_parenthesized))))))))
 
 ======

--- a/test/corpus/expr/record.nu
+++ b/test/corpus/expr/record.nu
@@ -351,14 +351,17 @@ k3.2: .1.
 k3.3: -1.1e-10.
 k4.0: foo(
   'bar')baz(
-  1)
+  1)qux
 k4.1:foo('bar')()
-  k4.2: .()
+k4.2: .()
 k4.3: true()
 k4.4: -()
 k4.5: ..=1()
 k4.6: ..1..<1()
-k4.9: 1...()}
+k4.9: 1...()
+k4.10: (1)foo
+k4.11: (1)(1)
+}
 
 -----
 
@@ -367,51 +370,51 @@ k4.9: 1...()}
     (pipe_element
       (val_record
         (record_body
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized
                 (pipeline
                   (pipe_element
@@ -421,39 +424,57 @@ k4.9: 1...()}
                 (pipeline
                   (pipe_element
                     (val_number))))))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized
                 (pipeline
                   (pipe_element
                     (val_string
                       (string_content)))))
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
               (expr_parenthesized)))
-          (record_entry
-            (identifier)
-            (val_string
-              (expr_parenthesized))))))))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
+              (expr_parenthesized)))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))))
+          entry: (record_entry
+            key: (identifier)
+            value: (val_string
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number))))
+              (expr_parenthesized
+                (pipeline
+                  (pipe_element
+                    (val_number)))))))))))
 
 =====
 record-015-separated-colon-vs-closure

--- a/test/corpus/pipe/commands.nu
+++ b/test/corpus/pipe/commands.nu
@@ -796,8 +796,10 @@ cmd-025-unquoted-string-with-immediate-expr-parenthesized
 
 echo foo(
 'bar')baz(
-1)
+1)qux
 echo foo('bar')()
+echo (1)(2)
+echo (1)foo
 echo .()
 echo true()
 echo null()
@@ -840,6 +842,28 @@ echo 1...()
                 (val_string
                   (string_content)))))
           (expr_parenthesized)))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string
+          (expr_parenthesized
+            (pipeline
+              (pipe_element
+                (val_number))))
+          (expr_parenthesized
+            (pipeline
+              (pipe_element
+                (val_number))))))))
+  (pipeline
+    (pipe_element
+      (command
+        (cmd_identifier)
+        (val_string
+          (expr_parenthesized
+            (pipeline
+              (pipe_element
+                (val_number))))))))
   (pipeline
     (pipe_element
       (command


### PR DESCRIPTION
While fixing #199, this PR will increase case number of `ts_ls` from 3376 to 4111. #185 

Not sure we want to land this.

Personally I'd like nushell to forbid all subexpressions in unquoted strings, because that's the job of `$""`/`$''` string interpolation in the first place. But the ease/robustness of parsing it brings won't worth such a huge breaking change, probably we still need this fix in the future and find another way to reduce the compilation time.  

