### PR TITLE
fix(highlight): highlight operators in where predicates

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -97,6 +97,9 @@ file_path: (val_string) @variable.parameter
 (expr_binary
   opr: _ @operator)
 
+(where_predicate
+  opr: _ @operator)
+
 (assignment [
     "="
     "+="


### PR DESCRIPTION
I don't know really know the performance characteristics of tree-sitter queries (nor how to benchmark them), so while just using a wildcard was my first instinct, I used an explicit where_predicate node.

Would this be better or worse?
```tree-sitter-query
(_
  opr: _ @operator)
``` 