### PR TITLE
fix: env_var with (interpolated) string as value

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1302,14 +1302,16 @@ module.exports = grammar({
 
     env_var: ($) =>
       seq(
+        field('variable', alias($.cmd_identifier, $.identifier)),
+        token.immediate(punc().eq),
         field(
-          'variable',
-          seq(
-            alias($.cmd_identifier, $.identifier),
-            token.immediate(punc().eq),
+          'value',
+          choice(
+            alias(_identifier_rules(true), $.val_string),
+            $.val_string,
+            $.val_interpolated,
           ),
         ),
-        field('value', alias(_identifier_rules(true), $.val_string)),
       ),
 
     /// Commands

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -16526,53 +16526,61 @@
           "type": "FIELD",
           "name": "variable",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "cmd_identifier"
-                },
-                "named": true,
-                "value": "identifier"
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "="
-                }
-              }
-            ]
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "cmd_identifier"
+            },
+            "named": true,
+            "value": "identifier"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "="
           }
         },
         {
           "type": "FIELD",
           "name": "value",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.&*!^+#$]"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.]"
-                    }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.&*!^+#$]"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[^\\s\\r\\n\\t\\|();\\[\\]\\-{}<>=\"`'@?,:.]"
+                        }
+                      }
+                    ]
                   }
-                ]
+                },
+                "named": true,
+                "value": "val_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "val_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "val_interpolated"
               }
-            },
-            "named": true,
-            "value": "val_string"
+            ]
           }
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1829,19 +1829,19 @@
         "required": true,
         "types": [
           {
+            "type": "val_interpolated",
+            "named": true
+          },
+          {
             "type": "val_string",
             "named": true
           }
         ]
       },
       "variable": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": "=",
-            "named": false
-          },
           {
             "type": "identifier",
             "named": true

--- a/test/corpus/pipe/env.nu
+++ b/test/corpus/pipe/env.nu
@@ -131,3 +131,35 @@ _SHELL_=🤖 hello=42 hello=你好 foo
         value: (val_string))
       (command
         head: (cmd_identifier)))))
+
+====
+env-005-string
+====
+
+FOO='bar' baz
+FOO=$"bar(baz)" qux
+
+-----
+
+(nu_script
+  (pipeline
+    (pipe_element
+      (env_var
+        variable: (identifier)
+        value: (val_string
+          (string_content)))
+      (command
+        head: (cmd_identifier))))
+  (pipeline
+    (pipe_element
+      (env_var
+        variable: (identifier)
+        value: (val_interpolated
+          (escaped_interpolated_content)
+          expr: (expr_interpolated
+            (pipeline
+              (pipe_element
+                (command
+                  head: (cmd_identifier)))))))
+      (command
+        head: (cmd_identifier)))))


### PR DESCRIPTION
Fixes the parsing error described in https://github.com/blindFS/topiary-nushell/issues/20

Known difference to native nu-parser after the fix:`FOO=(bar) baz` 
1. error by tree-sitter-nu.
2. assign a string of `'(bar)'` (with the parentheses) to env variable `FOO` in nu

I guess that's a corner case nobody actually cares.