### PR TITLE
fix(collections): handle untyped collection body

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -308,11 +308,14 @@ module.exports = grammar({
         optional($._collection_annotation),
       ),
     _collection_body: ($) =>
-      general_body_rules(
-        '',
+      choice(
         $._collection_entry,
-        $._entry_separator,
-        $._newline,
+        general_body_rules(
+          '',
+          $._collection_entry,
+          $._entry_separator,
+          $._newline,
+        ),
       ),
     collection_type: ($) =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3006,50 +3006,59 @@
       ]
     },
     "_collection_body": {
-      "type": "PREC",
-      "value": 20,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_collection_entry"
+        },
+        {
+          "type": "PREC",
+          "value": 20,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "REPEAT",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "_collection_entry"
-                },
-                {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_entry_separator"
-                  }
+                  "name": "_newline"
                 }
-              ]
-            }
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_collection_entry"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_entry_separator"
-            }
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_collection_entry"
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_entry_separator"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_collection_entry"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_entry_separator"
+                }
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "collection_type": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -562,6 +562,7 @@
   {
     "type": "comment",
     "named": true,
+    "extra": true,
     "fields": {}
   },
   {

--- a/test/corpus/decl/def.nu
+++ b/test/corpus/decl/def.nu
@@ -1088,6 +1088,7 @@ def-036-untyped-collection-body
 
 def test [name: record<name>] {}
 def test [name: record<name,>] {}
+def test [name: record<name, value>] {}
 
 -----
 

--- a/test/corpus/decl/def.nu
+++ b/test/corpus/decl/def.nu
@@ -1081,3 +1081,32 @@ oneof<int, bool>> {}
           type: (flat_type)
           type: (flat_type))))
     body: (block)))
+
+=====
+def-036-untyped-collection-body
+=====
+
+def test [name: record<name>] {}
+def test [name: record<name,>] {}
+
+-----
+
+(nu_script
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (flat_type)))
+      (ERROR))
+    (block))
+  (decl_def
+    (cmd_identifier)
+    (parameter_bracks
+      (parameter
+        (identifier)
+        (param_type
+          (collection_type
+            (identifier)))))
+    (block)))


### PR DESCRIPTION
Handle instances where tables/record have untyped parameters:
https://github.com/nushell/nushell/blob/9ebb02d23691a373298ac019d5081df508513733/tests/repl/test_signatures.rs#L219-L223