### PR TITLE
feat!: add support of new custom constant completer syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -158,7 +158,7 @@ module.exports = grammar({
         optional(modifier().visibility),
         keyword().def,
         repeat($.long_flag),
-        field('name', $._command_name),
+        $._command_name,
         repeat($.long_flag),
         field('parameters', choice($.parameter_parens, $.parameter_bracks)),
         field('return_type', optional($.returns)),
@@ -172,7 +172,7 @@ module.exports = grammar({
         optional($.attribute_list),
         optional(modifier().visibility),
         keyword().extern,
-        field('name', $._command_name),
+        $._command_name,
         field('signature', choice($.parameter_parens, $.parameter_bracks)),
         field('body', optional($.block)),
       ),
@@ -181,7 +181,7 @@ module.exports = grammar({
       seq(
         optional(modifier().visibility),
         keyword().module,
-        field('name', $._command_name),
+        $._command_name,
         optional(field('body', $.block)),
       ),
 
@@ -259,7 +259,7 @@ module.exports = grammar({
         punc().colon,
         optional($._repeat_newline),
         $._type_annotation,
-        field('completion', optional($.param_cmd)),
+        field('completion', optional($.param_completer)),
       ),
 
     param_value: ($) =>
@@ -295,7 +295,7 @@ module.exports = grammar({
       seq(
         punc().colon,
         $._all_type,
-        field('completion', optional($.param_cmd)),
+        field('completion', optional($.param_completer)),
       ),
     _collection_entry: ($) =>
       seq(
@@ -328,7 +328,7 @@ module.exports = grammar({
         'list',
         token.immediate(brack().open_angle),
         field('inner', optional($._all_type)),
-        field('completion', optional($.param_cmd)),
+        field('completion', optional($.param_completer)),
         brack().close_angle,
       ),
 
@@ -342,8 +342,14 @@ module.exports = grammar({
         brack().close_angle,
       ),
 
-    param_cmd: ($) =>
-      seq(token.immediate(punc().at), field('name', $._command_name)),
+    param_completer: ($) =>
+      seq(
+        token.immediate(punc().at),
+        choice($._command_name,
+          field('const', $.val_list),
+          field('const', $.val_record),
+          field('const', $.val_variable)),
+      ),
 
     param_rest: ($) =>
       seq(punc().rest, optional(punc().dollar), field('name', $.identifier)),
@@ -556,7 +562,7 @@ module.exports = grammar({
     scope_pattern: ($) =>
       choice(
         field('wildcard', $.wild_card),
-        field('command', $._command_name),
+        $._command_name,
         field('command_list', $.command_list),
       ),
 
@@ -1451,7 +1457,7 @@ function _block_body_rules(suffix) {
       seq(
         optional(modifier().visibility),
         keyword().alias,
-        field('name', $._command_name),
+        $._command_name,
         punc().eq,
         field('value', alias_for_suffix($, 'pipeline', suffix)),
       ),

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -201,7 +201,7 @@ file_path: (val_string) @variable.parameter
 (param_value
   "=" @punctuation.special)
 
-(param_cmd
+(param_completer
   "@" @punctuation.special)
 
 (attribute
@@ -242,7 +242,7 @@ key: (identifier) @property
 (parameter
   param_name: (_) @variable.parameter)
 
-(param_cmd
+(param_completer
   (cmd_identifier) @string)
 
 (param_long_flag

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -119,12 +119,8 @@
           "value": "alias"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "STRING",
@@ -439,12 +435,8 @@
           "value": "alias"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "STRING",
@@ -2029,12 +2021,8 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "REPEAT",
@@ -2135,12 +2123,8 @@
           "value": "extern"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "FIELD",
@@ -2197,12 +2181,8 @@
           "value": "module"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "CHOICE",
@@ -2662,7 +2642,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "param_cmd"
+                "name": "param_completer"
               },
               {
                 "type": "BLANK"
@@ -2958,7 +2938,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "param_cmd"
+                "name": "param_completer"
               },
               {
                 "type": "BLANK"
@@ -3137,7 +3117,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "param_cmd"
+                "name": "param_completer"
               },
               {
                 "type": "BLANK"
@@ -3221,7 +3201,7 @@
         }
       ]
     },
-    "param_cmd": {
+    "param_completer": {
       "type": "SEQ",
       "members": [
         {
@@ -3232,12 +3212,37 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_command_name"
+            },
+            {
+              "type": "FIELD",
+              "name": "const",
+              "content": {
+                "type": "SYMBOL",
+                "name": "val_list"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "const",
+              "content": {
+                "type": "SYMBOL",
+                "name": "val_record"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "const",
+              "content": {
+                "type": "SYMBOL",
+                "name": "val_variable"
+              }
+            }
+          ]
         }
       ]
     },
@@ -4546,12 +4551,8 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "command",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_command_name"
-          }
+          "type": "SYMBOL",
+          "name": "_command_name"
         },
         {
           "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -318,7 +318,7 @@
         "required": false,
         "types": [
           {
-            "type": "param_cmd",
+            "type": "param_completer",
             "named": true
           }
         ]
@@ -562,7 +562,6 @@
   {
     "type": "comment",
     "named": true,
-    "extra": true,
     "fields": {}
   },
   {
@@ -1165,20 +1164,6 @@
     "type": "decl_alias",
     "named": true,
     "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "cmd_identifier",
-            "named": true
-          },
-          {
-            "type": "val_string",
-            "named": true
-          }
-        ]
-      },
       "quoted_name": {
         "multiple": false,
         "required": false,
@@ -1221,20 +1206,6 @@
         "types": [
           {
             "type": "block",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "cmd_identifier",
-            "named": true
-          },
-          {
-            "type": "val_string",
             "named": true
           }
         ]
@@ -1329,20 +1300,6 @@
           }
         ]
       },
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "cmd_identifier",
-            "named": true
-          },
-          {
-            "type": "val_string",
-            "named": true
-          }
-        ]
-      },
       "quoted_name": {
         "multiple": false,
         "required": false,
@@ -1399,20 +1356,6 @@
         "types": [
           {
             "type": "block",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "cmd_identifier",
-            "named": true
-          },
-          {
-            "type": "val_string",
             "named": true
           }
         ]
@@ -2341,7 +2284,7 @@
         "required": false,
         "types": [
           {
-            "type": "param_cmd",
+            "type": "param_completer",
             "named": true
           }
         ]
@@ -2803,19 +2746,23 @@
     }
   },
   {
-    "type": "param_cmd",
+    "type": "param_completer",
     "named": true,
     "fields": {
-      "name": {
+      "const": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
-            "type": "cmd_identifier",
+            "type": "val_list",
             "named": true
           },
           {
-            "type": "val_string",
+            "type": "val_record",
+            "named": true
+          },
+          {
+            "type": "val_variable",
             "named": true
           }
         ]
@@ -2914,7 +2861,7 @@
         "required": false,
         "types": [
           {
-            "type": "param_cmd",
+            "type": "param_completer",
             "named": true
           }
         ]
@@ -3514,20 +3461,6 @@
     "type": "scope_pattern",
     "named": true,
     "fields": {
-      "command": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "cmd_identifier",
-            "named": true
-          },
-          {
-            "type": "val_string",
-            "named": true
-          }
-        ]
-      },
       "command_list": {
         "multiple": false,
         "required": false,

--- a/test/corpus/decl/def.nu
+++ b/test/corpus/decl/def.nu
@@ -1009,13 +1009,13 @@ def test [
         param_name: (identifier)
         (param_type
           type: (flat_type)
-          completion: (param_cmd
+          completion: (param_completer
             unquoted_name: (cmd_identifier))))
       (parameter
         param_name: (identifier)
         (param_type
           type: (flat_type)
-          completion: (param_cmd
+          completion: (param_completer
             quoted_name: (val_string
               (string_content)))))
       (parameter
@@ -1027,7 +1027,7 @@ def test [
         (param_type
           type: (list_type
             type: (flat_type)
-            completion: (param_cmd
+            completion: (param_completer
               unquoted_name: (cmd_identifier))))
         (param_value
           param_value: (val_string)))
@@ -1184,3 +1184,71 @@ def test [name: record<name, value,>, name: record<"name", "value",>] {}
             (identifier
               (string_content))))))
     (block)))
+
+======
+def-037-constant-param-completer
+======
+
+def test [
+  x: int@[1 2],
+  y: string@{f: [a b]}.f,
+  --zero(-z): list<string@$var.cell?>
+= [a b],
+] {}
+
+-----
+
+(nu_script
+  (decl_def
+    unquoted_name: (cmd_identifier)
+    parameters: (parameter_bracks
+      (parameter
+        param_name: (identifier)
+        (param_type
+          type: (flat_type)
+          completion: (param_completer
+            const: (val_list
+              (list_body
+                entry: (val_entry
+                  item: (val_number))
+                entry: (val_entry
+                  item: (val_number)))))))
+      (parameter
+        param_name: (identifier)
+        (param_type
+          type: (flat_type)
+          completion: (param_completer
+            const: (val_record
+              (record_body
+                entry: (record_entry
+                  key: (identifier)
+                  value: (val_list
+                    (list_body
+                      entry: (val_entry
+                        item: (val_string))
+                      entry: (val_entry
+                        item: (val_string))))))
+              (cell_path
+                (path))))))
+      (parameter
+        param_long_flag: (param_long_flag
+          (long_flag_identifier))
+        flag_capsule: (flag_capsule
+          (param_short_flag
+            name: (param_short_flag_identifier)))
+        (param_type
+          type: (list_type
+            type: (flat_type)
+            completion: (param_completer
+              const: (val_variable
+                name: (identifier)
+                (cell_path
+                  (path))))))
+        (param_value
+          param_value: (val_list
+            (list_body
+              entry: (val_entry
+                item: (val_string))
+              entry: (val_entry
+                item: (val_string)))))))
+    body: (block)))


### PR DESCRIPTION
https://github.com/nushell/nushell/pull/16789

A breaking change since `param_cmd` is now renamed as `param_completer`.