### PR TITLE
Expose the Highlights query at crate level

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -34,7 +34,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/nu/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");


### PR DESCRIPTION
When tree-sitter-nu crate gets published, this will allow it to be easily integrated in other tools that use treesitter highlighting, such as Difftastic.

Issue #245 