### PR TITLE
fix(scanner): avoid out-of-bounds read of valid_symbols during error recovery

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -113,7 +113,13 @@ bool tree_sitter_nu_external_scanner_scan(
     TSLexer *lexer,
     const bool *valid_symbols
 ) {
-    if (valid_symbols[ERROR_SENTINEL]) {
+    // During error recovery tree-sitter marks every real external token as
+    // valid; ERROR_SENTINEL is not a declared external token, so indexing
+    // valid_symbols[ERROR_SENTINEL] reads past the end of the array. Detect
+    // error recovery by checking only the valid, in-range token slots.
+    if (valid_symbols[RAW_STRING_BEGIN] &&
+        valid_symbols[RAW_STRING_CONTENT] &&
+        valid_symbols[RAW_STRING_END]) {
         return false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/nushell/tree-sitter-nu/issues/257

## What

Fixes a **global-buffer-overflow** in the external scanner (`src/scanner.c`).

## Root cause

The scanner reads `valid_symbols[ERROR_SENTINEL]` (around line 116), but `ERROR_SENTINEL` is not a declared external token — only 3 tokens are declared in `externals`, so `valid_symbols` is sized for 3 and the index reads past the end of the array.

## Fix

Removes the invalid `valid_symbols[ERROR_SENTINEL]` access and instead detects error recovery by checking only the real, in-range token slots (`RAW_STRING_BEGIN` / `RAW_STRING_CONTENT` / `RAW_STRING_END`).

The patch was generated with LLM assistance and **auto-verified**: after applying it and
rebuilding at the tested commit, the crashing input no longer triggers the bug when replayed
under the same libFuzzer + AddressSanitizer time / memory budget. Please review it on those
terms — it may include incidental reformatting.

## Provenance

Found with an automated libFuzzer + AddressSanitizer fuzzing pipeline, as part of a research
project on hardening tree-sitter grammars. A self-contained reproducer is available on
request (see the linked issue).
